### PR TITLE
Introduces state Module property and logical reset handling

### DIFF
--- a/source/application.coffee
+++ b/source/application.coffee
@@ -12,49 +12,7 @@ class Space.Application extends Space.Module
   constructor: (options={}) ->
     super
     @modules = {}
-    @injector = options.injector ? new Space.Injector()
-    mergedConfig = {}
-    @injector.map('Configuration').to mergedConfig
-    @injector.map('Injector').to @injector
-
-    # Map Meteor standard packages
-    @injector.map('Meteor').to Meteor
-    if Package.ejson?
-      @injector.map('EJSON').to Package.ejson.EJSON
-    if Package.ddp?
-      @injector.map('DDP').to Package.ddp.DDP
-    if Package.random?
-      @injector.map('Random').to Package.random.Random
-    @injector.map('underscore').to Package.underscore._
-    if Package.mongo?
-      @injector.map('Mongo').to Package.mongo.Mongo
-
-    if Meteor.isClient
-      if Package.tracker?
-        @injector.map('Tracker').to Package.tracker.Tracker
-      if Package.templating?
-        @injector.map('Template').to Package.templating.Template
-      if Package.session?
-        @injector.map('Session').to Package.session.Session
-      if Package.blaze?
-        @injector.map('Blaze').to Package.blaze.Blaze
-
-    if Meteor.isServer
-      @injector.map('check').to check
-      @injector.map('Match').to Match
-      @injector.map('process').to process
-      @injector.map('Future').to Npm.require 'fibers/future'
-
-      if Package.email?
-        @injector.map('Email').to Package.email.Email
-
-    if Package['accounts-base']?
-      @injector.map('Accounts').to Package['accounts-base'].Accounts
-
-    if Package['reactive-var']?
-      @injector.map('ReactiveVar').to Package['reactive-var'].ReactiveVar
-
-    @initialize this, @injector, mergedConfig
+    @initialize this, options.injector ? new Space.Injector(), {}
 
   # Make it possible to override configuration (at any nested level)
   configure: (options) -> _.deepExtend @Configuration, options

--- a/source/helpers.coffee
+++ b/source/helpers.coffee
@@ -22,3 +22,6 @@ Space.resolvePath = (path) ->
   return result
 
 Space.namespace = (id) -> Space.namespaces[id] = {}
+
+Space.capitalizeString = (string) ->
+  string.charAt(0).toUpperCase() + string.slice(1)

--- a/source/helpers.coffee
+++ b/source/helpers.coffee
@@ -25,3 +25,12 @@ Space.namespace = (id) -> Space.namespaces[id] = {}
 
 Space.capitalizeString = (string) ->
   string.charAt(0).toUpperCase() + string.slice(1)
+
+Space.stringToBoolean = (string) ->
+  switch string.toLowerCase().trim()
+    when 'true', 'yes', '1'
+      return true
+    when 'false', 'no', '0', null
+      return false
+    else
+      return Boolean(string)

--- a/source/module.coffee
+++ b/source/module.coffee
@@ -134,6 +134,8 @@ class Space.Module extends Space.Object
     @injector.map('underscore').to Package.underscore._
     if Package.mongo?
       @injector.map('Mongo').to Package.mongo.Mongo
+      if Meteor.isServer
+        @injector.map('MongoInternals').to Package.mongo.MongoInternals
 
     if Meteor.isClient
       if Package.tracker?

--- a/source/module.coffee
+++ b/source/module.coffee
@@ -28,22 +28,26 @@ class Space.Module extends Space.Object
 
     if not @injector? then throw new Error Space.Module.ERRORS.injectorMissing
 
+    # merge any supplied config into this Module's Configuration
+    _.deepExtend(@Configuration, mergedConfig)
+
     # Setup required modules
     for moduleId in @RequiredModules
 
-      # Create a new module instance if non exist in the app
+      # Create a new module instance if not already registered with the app
       unless @app.modules[moduleId]?
         moduleClass = Space.Module.require(moduleId, this.constructor.name)
         @app.modules[moduleId] = new moduleClass()
 
       # Initialize required module
       module = @app.modules[moduleId]
-      module.initialize(@app, @injector, mergedConfig) if !module.isInitialized
+      module.initialize(@app, @injector, @Configuration) if !module.isInitialized
+
     @beforeInitialize?()
+
     # After the required modules have been configured, merge in the own
     # configuration to give the chance for overwriting.
-    _.deepExtend(mergedConfig, @constructor::Configuration)
-    @Configuration = mergedConfig
+    @Configuration = _.deepExtend(mergedConfig, @constructor::Configuration )
 
     # Give every module access Npm
     if Meteor.isServer then @npm = Npm

--- a/source/module.coffee
+++ b/source/module.coffee
@@ -107,17 +107,14 @@ class Space.Module extends Space.Object
   # calling the instance hooks before, on, and after
   _runLifeCycleAction: (action, func) ->
     @_invokeActionOnRequiredModules action
-    this["before#{@_capitalize(action)}"]?()
+    this["before#{Space.capitalizeString(action)}"]?()
     func?()
-    this["on#{@_capitalize(action)}"]?()
-    this["after#{@_capitalize(action)}"]?()
+    this["on#{Space.capitalizeString(action)}"]?()
+    this["after#{Space.capitalizeString(action)}"]?()
 
   _runAfterInitializeHook: ->
     @_invokeActionOnRequiredModules '_runAfterInitializeHook'
     @afterInitialize?()
-
-  _capitalize: (string) ->
-    string.charAt(0).toUpperCase() + string.slice(1)
 
   _invokeActionOnRequiredModules: (action) ->
     @app.modules[moduleId][action]?() for moduleId in @RequiredModules

--- a/source/module.coffee
+++ b/source/module.coffee
@@ -13,12 +13,7 @@ class Space.Module extends Space.Object
 
   injector: null
   isInitialized: false
-  isConfigured: false
   state: 'stopped'
-  # Depreciated: use state instead
-  isRunning: false
-  isStopped: true
-  # --
 
   constructor: ->
     super
@@ -65,11 +60,6 @@ class Space.Module extends Space.Object
     @_runLifeCycleAction 'start', => @injector.create(singleton) for singleton in @Singletons
     @state = 'running'
 
-    # Backwards compatibility
-    @isStopped = false
-    @isRunning = true
-    # --
-
   reset: ->
 
     restartRequired = true if @state is 'running'
@@ -82,11 +72,6 @@ class Space.Module extends Space.Object
     if @state is 'stopped' then return
     @_runLifeCycleAction 'stop', =>
     @state = 'stopped'
-
-    # Backwards compatibility
-    @isStopped = true
-    @isRunning = false
-    # --
 
   # ========== STATIC MODULE MANAGEMENT ============ #
 

--- a/source/module.coffee
+++ b/source/module.coffee
@@ -116,7 +116,6 @@ class Space.Module extends Space.Object
   # Invokes the lifecycle action on all required modules, then on itself,
   # calling the instance hooks before, on, and after
   _runLifeCycleAction: (action, func) ->
-    console.log(func.toString())
 
     @_invokeActionOnRequiredModules action
     this["before#{@_capitalize(action)}"]?()

--- a/source/module.coffee
+++ b/source/module.coffee
@@ -3,7 +3,6 @@ class Space.Module extends Space.Object
 
   @ERRORS: {
     injectorMissing: 'Instance of Space.Injector needed to initialize module.'
-    alreadyInitialized: 'Module was already initialized.'
   }
 
   Configuration: {}

--- a/tests/integration/lifecycle_hooks.tests.js
+++ b/tests/integration/lifecycle_hooks.tests.js
@@ -18,21 +18,29 @@ describe("Space.base - Application lifecycle hooks", function () {
   });
 
   it("runs the start hooks in correct order", function () {
-    expectHooksNotCalledYet(this, 'beforeStart', 'onStart', 'afterStart');
+    expectHooksNotToBeCalledYet(this, 'beforeStart', 'onStart', 'afterStart');
     this.app.start();
     testOrderOfLifecycleHook(this, 'beforeStart', 'onStart', 'afterStart');
   });
 
-  it("runs the reset hooks in correct order", function () {
-    expectHooksNotCalledYet(this, 'beforeReset', 'onReset', 'afterReset');
-    this.app.reset();
-    testOrderOfLifecycleHook(this, 'beforeReset', 'onReset', 'afterReset');
-  });
-
   it("runs the stop hooks in correct order", function () {
-    expectHooksNotCalledYet(this, 'beforeStop', 'onStop', 'afterStop');
+    expectHooksNotToBeCalledYet(this, 'beforeStop', 'onStop', 'afterStop');
+    this.app.start();
     this.app.stop();
     testOrderOfLifecycleHook(this, 'beforeStop', 'onStop', 'afterStop');
+  });
+
+  it("runs the reset hooks in correct order when app is running", function () {
+    expectHooksNotToBeCalledYet(this, 'beforeReset', 'onReset', 'afterReset');
+    this.app.start();
+    this.app.reset();
+    testOrderOfLifecycleHook(this, 'beforeStop', 'onStop', 'afterStop','beforeReset', 'onReset', 'afterReset','beforeStart', 'onStart', 'afterStart');
+  });
+
+  it("runs the reset hooks in correct order when app is stopped", function () {
+    expectHooksNotToBeCalledYet(this, 'beforeReset', 'onReset', 'afterReset');
+    this.app.reset();
+    testOrderOfLifecycleHook(this, 'beforeReset', 'onReset', 'afterReset');
   });
 
   // TEST HELPERS
@@ -67,7 +75,7 @@ describe("Space.base - Application lifecycle hooks", function () {
     }
   }
 
-  function expectHooksNotCalledYet(context, before, on, after) {
+  function expectHooksNotToBeCalledYet(context, before, on, after) {
     modules = ['firstHooks', 'secondHooks', 'appHooks'];
     hooks = [before, on, after];
     for(var i=0; i < 3; i++) {

--- a/tests/integration/standalone_application.integration.coffee
+++ b/tests/integration/standalone_application.integration.coffee
@@ -67,7 +67,6 @@ describe 'Meteor integration in applications', ->
           expect(@blaze).to.be.defined
           expect(@blaze).to.equal Blaze
 
-
       new ClientApp()
 
     # SERVER ONLY
@@ -80,6 +79,7 @@ describe 'Meteor integration in applications', ->
           email: 'Email'
           process: 'process'
           Future: 'Future'
+          mongoInternals: 'MongoInternals'
 
         onInitialize: ->
           expect(@email).to.be.defined
@@ -88,4 +88,7 @@ describe 'Meteor integration in applications', ->
           expect(@process).to.equal process
           expect(@Future).to.be.defined
           expect(@Future).to.equal Npm.require 'fibers/future'
+          expect(@mongoInternals).to.be.defined
+          expect(@mongoInternals).to.equal MongoInternals
+
       new ServerApp()

--- a/tests/unit/application.unit.coffee
+++ b/tests/unit/application.unit.coffee
@@ -54,7 +54,7 @@ describe 'Space.Application', ->
           }
         }
         afterInitialize: ->
-          expect(@Configuration).to.deep.equal {
+          expect(@Configuration).toMatch {
             toChange: 'appChangeMe'
             toKeep: 'appKeepMe'
             child: {
@@ -92,7 +92,7 @@ describe 'Space.Application', ->
           toChange: 'grandchildNewValue'
         }
       }
-      expect(app.injector.get 'Configuration').to.deep.equal {
+      expect(app.injector.get 'Configuration').toMatch {
         toChange: 'appNewValue'
         toKeep: 'appKeepMe'
         child: {

--- a/tests/unit/application.unit.coffee
+++ b/tests/unit/application.unit.coffee
@@ -53,7 +53,7 @@ describe 'Space.Application', ->
             toKeep: 'grandchildKeepMe'
           }
         }
-        onInitialize: ->
+        afterInitialize: ->
           expect(@Configuration).to.deep.equal {
             toChange: 'appChangeMe'
             toKeep: 'appKeepMe'
@@ -104,5 +104,3 @@ describe 'Space.Application', ->
           toKeep: 'grandchildKeepMe'
         }
       }
-
-

--- a/tests/unit/application.unit.coffee
+++ b/tests/unit/application.unit.coffee
@@ -45,48 +45,64 @@ describe 'Space.Application', ->
       initializeSpy.restore()
 
     it 'merges configurations of all modules and user options', ->
-      class FirstModule extends Space.Module
-        @publish this, 'FirstModule'
+      class GrandchildModule extends Space.Module
+        @publish this, 'GrandchildModule'
         Configuration: {
-          first: {
-            toChange: 'first'
-            toKeep: 'first'
+          grandchild: {
+            toChange: 'grandchildChangeMe'
+            toKeep: 'grandchildKeepMe'
           }
         }
-      class SecondModule extends Space.Module
-        @publish this, 'SecondModule'
-        RequiredModules: ['FirstModule']
+        onInitialize: ->
+          expect(@Configuration).to.deep.equal {
+            toChange: 'appChangeMe'
+            toKeep: 'appKeepMe'
+            child: {
+              toChange: 'childChangeMe'
+              toKeep: 'childKeepMe'
+            }
+            grandchild: {
+              toChange: 'grandchildChangeMe'
+              toKeep: 'grandchildKeepMe'
+            }
+          }
+
+      class ChildModule extends Space.Module
+        @publish this, 'ChildModule'
+        RequiredModules: ['GrandchildModule']
         Configuration: {
-          second: {
-            toChange: 'second'
-            toKeep: 'second'
+          child: {
+            toChange: 'childChangeMe'
+            toKeep: 'childKeepMe'
           }
         }
       class TestApp extends Space.Application
-        RequiredModules: ['SecondModule']
+        RequiredModules: ['ChildModule']
         Configuration: {
-          toChange: 'app'
-          toKeep: 'app'
+          toChange: 'appChangeMe'
+          toKeep: 'appKeepMe'
         }
       app = new TestApp()
       app.configure {
-        toChange: 'appPropChanged'
-        first: {
-          toChange: 'firstChanged'
+        toChange: 'appNewValue'
+        child: {
+          toChange: 'childNewValue'
         }
-        second: {
-          toChange: 'secondChanged'
+        grandchild: {
+          toChange: 'grandchildNewValue'
         }
       }
       expect(app.injector.get 'Configuration').to.deep.equal {
-        toChange: 'appPropChanged'
-        toKeep: 'app'
-        first: {
-          toChange: 'firstChanged'
-          toKeep: 'first'
+        toChange: 'appNewValue'
+        toKeep: 'appKeepMe'
+        child: {
+          toChange: 'childNewValue'
+          toKeep: 'childKeepMe'
         }
-        second: {
-          toChange: 'secondChanged'
-          toKeep: 'second'
+        grandchild: {
+          toChange: 'grandchildNewValue'
+          toKeep: 'grandchildKeepMe'
         }
       }
+
+

--- a/tests/unit/module.unit.coffee
+++ b/tests/unit/module.unit.coffee
@@ -10,23 +10,21 @@ describe 'Space.Module', ->
   describe '@publish', ->
 
     it 'adds given module to the static collection of published modules', ->
-      fakeModule = identifier = 'test'
-      Space.Module.publish fakeModule, fakeModule.identifier
-      expect(Space.Module.published[fakeModule.identifier]).to.equal fakeModule
+      module = Space.Module.define 'test'
+      expect(Space.Module.published['test']).to.equal module
 
     it 'throws an error if two modules try to publish under same name', ->
       publishTwoModulesWithSameName = ->
-        Space.Module.publish {}, 'test'
-        Space.Module.publish {}, 'test'
+        Space.Module.define 'test'
+        Space.Module.define 'test'
       expect(publishTwoModulesWithSameName).to.throw Error
 
   describe '@require', ->
 
     it 'returns published module for given identifier', ->
-      fakeModule = identifier = 'test'
-      Space.Module.publish fakeModule, fakeModule.identifier
-      requiredModule = Space.Module.require fakeModule.identifier
-      expect(requiredModule).to.equal fakeModule
+      module = Space.Module.define 'test'
+      requiredModule = Space.Module.require 'test'
+      expect(requiredModule).to.equal module
 
     it 'throws and error if no module was registered for given identifier', ->
       requireUnkownModule = -> Space.Module.require 'unknown module'

--- a/tests/unit/module.unit.coffee
+++ b/tests/unit/module.unit.coffee
@@ -49,7 +49,6 @@ describe 'Space.Module', ->
     it 'sets the correct state', ->
       module = new Space.Module()
       expect(module.isInitialized).to.be.false
-      expect(module.isConfigured).to.be.false
       expect(module.state).to.equal 'stopped'
 
 
@@ -141,11 +140,6 @@ describe 'Space.Module - #start', ->
   it 'sets the state to running', ->
     expect(@module.state).to.equal('running')
 
-    # Backwards compatibility
-    expect(@module.isRunning).to.be.true
-    expect(@module.isStopped).to.be.false
-    # --
-
   it 'ignores start calls on a running module', ->
     @module.start()
     expect(@module._runLifeCycleAction).not.to.have.been.called
@@ -158,13 +152,8 @@ describe 'Space.Module - #stop', ->
     @module.stop()
     @module._runLifeCycleAction = sinon.spy()
 
-
   it 'sets the state to stopped', ->
     expect(@module.state).to.equal('stopped')
-    # Backwards compatibility
-    expect(@module.isRunning).to.be.false
-    expect(@module.isStopped).to.be.true
-    # --
 
   it 'ignores stop calls on a stopped module', ->
     @module.stop()

--- a/tests/unit/module.unit.coffee
+++ b/tests/unit/module.unit.coffee
@@ -46,6 +46,13 @@ describe 'Space.Module', ->
       module = Space.Module.create RequiredModules: testArray
       expect(module.RequiredModules).to.equal testArray
 
+    it 'sets the correct state', ->
+      module = new Space.Module()
+      expect(module.isInitialized).to.be.false
+      expect(module.isConfigured).to.be.false
+      expect(module.state).to.equal 'stopped'
+
+
 describe 'Space.Module - #initialize', ->
 
   beforeEach ->
@@ -123,3 +130,42 @@ describe 'Space.Module - #initialize', ->
 
     expect(@fakeModule1.initialize).not.to.have.been.called
     expect(@fakeModule2.initialize).not.to.have.been.called
+
+describe 'Space.Module - #start', ->
+
+  beforeEach ->
+    @module = new Space.Module()
+    @module.start()
+    @module._runLifeCycleAction = sinon.spy()
+
+  it 'sets the state to running', ->
+    expect(@module.state).to.equal('running')
+
+    # Backwards compatibility
+    expect(@module.isRunning).to.be.true
+    expect(@module.isStopped).to.be.false
+    # --
+
+  it 'ignores start calls on a running module', ->
+    @module.start()
+    expect(@module._runLifeCycleAction).not.to.have.been.called
+
+describe 'Space.Module - #stop', ->
+
+  beforeEach ->
+    @module = new Space.Module()
+    @module.start()
+    @module.stop()
+    @module._runLifeCycleAction = sinon.spy()
+
+
+  it 'sets the state to stopped', ->
+    expect(@module.state).to.equal('stopped')
+    # Backwards compatibility
+    expect(@module.isRunning).to.be.false
+    expect(@module.isStopped).to.be.true
+    # --
+
+  it 'ignores stop calls on a stopped module', ->
+    @module.stop()
+    expect(@module._runLifeCycleAction).not.to.have.been.called

--- a/tests/unit/module.unit.coffee
+++ b/tests/unit/module.unit.coffee
@@ -15,11 +15,9 @@ describe 'Space.Module', ->
       expect(Space.Module.published[fakeModule.identifier]).to.equal fakeModule
 
     it 'throws an error if two modules try to publish under same name', ->
-      subModule1 = identifier: 'test'
-      subModule2 = identifier: 'test'
       publishTwoModulesWithSameName = ->
-        Space.Module.publish subModule1, subModule1.identifier
-        Space.Module.publish subModule2, subModule2.identifier
+        Space.Module.publish {}, 'test'
+        Space.Module.publish {}, 'test'
       expect(publishTwoModulesWithSameName).to.throw Error
 
   describe '@require', ->

--- a/tests/unit/module.unit.coffee
+++ b/tests/unit/module.unit.coffee
@@ -48,15 +48,15 @@ describe 'Space.Module', ->
 
     it 'sets the correct state', ->
       module = new Space.Module()
-      expect(module.isInitialized).to.be.false
-      expect(module.state).to.equal 'stopped'
+      expect(module.is 'constructed').to.be.true
 
 
 describe 'Space.Module - #initialize', ->
 
   beforeEach ->
     @app = modules: {}
-    @injector = injectInto: sinon.spy()
+    @injector = new Space.Injector()
+    sinon.spy @injector, 'injectInto'
     @requireStub = sinon.stub Space.Module, 'require'
     @module = new Space.Module()
 
@@ -90,7 +90,7 @@ describe 'Space.Module - #initialize', ->
 
   it 'sets the initialized flag correctly', ->
     @module.initialize @app, @injector
-    expect(@module.isInitialized).to.be.true
+    expect(@module.is 'initialized').to.be.true
 
   it.server 'adds Npm as property to the module', ->
     @module.initialize @app, @injector
@@ -138,7 +138,7 @@ describe 'Space.Module - #start', ->
     @module._runLifeCycleAction = sinon.spy()
 
   it 'sets the state to running', ->
-    expect(@module.state).to.equal('running')
+    expect(@module.is 'running').to.be.true
 
   it 'ignores start calls on a running module', ->
     @module.start()
@@ -153,7 +153,7 @@ describe 'Space.Module - #stop', ->
     @module._runLifeCycleAction = sinon.spy()
 
   it 'sets the state to stopped', ->
-    expect(@module.state).to.equal('stopped')
+    expect(@module.is 'stopped').to.be.true
 
   it 'ignores stop calls on a stopped module', ->
     @module.stop()


### PR DESCRIPTION
Depreciates `isRunning`, `isStopped`, and removes `isReset` which was not usable anyway. `reset()` now stops a running app first, then restarts it, so the module’s running state is maintained.