### PR TITLE
makes fields api of Space.Struct more flexible

### DIFF
--- a/source/struct.coffee
+++ b/source/struct.coffee
@@ -1,18 +1,20 @@
 
 class Space.Struct extends Space.Object
 
+  @fields: {}
+
   constructor: (data) ->
-    fields = @_getFields()
+    fields = @fields()
     data ?= {}
     # Use the fields configuration to check given data during runtime
-    if fields? then check data, fields
+    check data, fields
     # Copy data to instance
     @[key] = data[key] for key of data
 
+  fields: -> _.clone(@constructor.fields) ? {}
+
   toPlainObject: ->
-    fields = @_getFields() ? {}
+    fields = @fields()
     copy = {}
     copy[key] = @[key] for key of fields when @[key]?
     return copy
-
-  _getFields: -> @constructor.fields

--- a/tests/unit/struct.unit.coffee
+++ b/tests/unit/struct.unit.coffee
@@ -4,10 +4,16 @@ describe 'Space.Struct', ->
   describe 'defining fields', ->
 
     class TestStruct extends Space.Struct
-      @fields: name: String, age: Match.Integer
+      fields: -> name: String, age: Match.Integer
 
     class StructWithNestedStructFields extends Space.Struct
-      @fields: sub: TestStruct
+      fields: -> sub: TestStruct
+
+    class ExtendedTestStruct extends TestStruct
+      fields: ->
+        fields = super()
+        fields.extra = Match.Integer
+        return fields
 
     it 'assigns the properties to the instance', ->
       properties = name: 'Dominik', age: 26
@@ -29,4 +35,18 @@ describe 'Space.Struct', ->
       expect(-> new TestStruct name: 5, age: 26, extra: 0).to.throw Match.Error
 
     it 'throws a match error if a property is missing', ->
+      expect(-> new TestStruct name: 5).to.throw Match.Error
+
+    it 'allows to extend the fields of base classes', ->
+      expect(-> new ExtendedTestStruct name: 'test', age: 26, extra: 0)
+      .not.to.throw Match.Error
+
+    # TODO: remove when breaking change is made for next major version:
+    it 'stays backward compatible with static fields api', ->
+      class TestStruct extends Space.Struct
+        @fields: { name: String, age: Match.Integer }
+
+      properties = name: 'Dominik', age: 26
+      instance = new TestStruct properties
+      expect(instance).toMatch properties
       expect(-> new TestStruct name: 5).to.throw Match.Error


### PR DESCRIPTION
This is a simple and backward-compatible improvement to the `Space.Struct` fields api.
Now you can define a `fields` method on the prototype that returns the EJSON / Match structure required for the struct. The cool thing is, that this now supports inheritance, so you can use whatever the super class returns for it's prototype method and extend that.

It stays backward-compatible because `Space.Struct::fields` returns the statically defined `fields` property on the current class by default (which was the previous api contract).