### PR TITLE
invoke mixin hooks on any inheritance level

### DIFF
--- a/source/object.coffee
+++ b/source/object.coffee
@@ -6,10 +6,14 @@ class Space.Object
   # Assign given properties to the instance
   constructor: (properties) -> @[key] = value for key, value of properties
 
-  onDependenciesReady: ->
-    if @constructor._mixinCallbacks?
+  onDependenciesReady: -> @_invokeMixinCallbacks @constructor
+
+  _invokeMixinCallbacks: (Class) ->
+    # Recursively walk up the inheritance chain
+    if Class.__super__? then @_invokeMixinCallbacks(Class.__super__.constructor)
+    if Class._mixinCallbacks?
       # Let mixins initialize themselves when dependencies are ready
-      callback.call(this) for callback in @constructor._mixinCallbacks
+      callback.call(this) for callback in Class._mixinCallbacks
 
   # Extends this class and return a child class with inherited prototype
   # and static properties.

--- a/tests/unit/object.unit.coffee
+++ b/tests/unit/object.unit.coffee
@@ -74,3 +74,24 @@ describe 'Space.Object', ->
       TestClass.mixin testMixin
       expect(TestClass::Dependencies.first).to.equal 'first'
       expect(TestClass::Dependencies.second).to.equal 'second'
+
+    it "can provide a hook that is called when the mixin is applied", ->
+      myMixin = onMixinApplied: sinon.spy()
+      TestClass = Space.Object.extend()
+      TestClass.mixin myMixin
+      expect(myMixin.onMixinApplied).to.have.been.calledOnce
+
+    it "can provide a hook that is called when dependencies of host class are ready", ->
+      myMixin = onDependenciesReady: sinon.spy()
+      TestClass = Space.Object.extend()
+      TestClass.mixin myMixin
+      new TestClass().onDependenciesReady()
+      expect(myMixin.onDependenciesReady).to.have.been.calledOnce
+
+    it "inherits the onDependenciesReady hook to sub classes", ->
+      myMixin = onDependenciesReady: sinon.spy()
+      SuperClass = Space.Object.extend()
+      SubClass = SuperClass.extend()
+      SuperClass.mixin myMixin
+      new SubClass().onDependenciesReady()
+      expect(myMixin.onDependenciesReady).to.have.been.calledOnce


### PR DESCRIPTION
This PR fixes a minor "bug" / introduces a new feature that all mixin callbacks are always invoked, no matter where in the inheritance chain they have been applied.