### PR TITLE
adds private api method for wrapping module lifecycle hooks

### DIFF
--- a/source/module.coffee
+++ b/source/module.coffee
@@ -121,6 +121,10 @@ class Space.Module extends Space.Object
   _invokeActionOnRequiredModules: (action) ->
     @app.modules[moduleId][action]?() for moduleId in @RequiredModules
 
+  _wrapLifecycleHook: (hook, wrapper) ->
+    this[hook] ?= ->
+    this[hook] = _.wrap(this[hook], wrapper)
+
   _mapMeteorApis: ->
     # Map Meteor standard packages
     @injector.map('Meteor').to Meteor


### PR DESCRIPTION
This is useful for scenarios where you want to
mixin functionality into the core classes like
Space.Module and need access to the lifecycle hooks.