### PR TITLE
Fix/module lifecycle logic

### DIFF
--- a/package.js
+++ b/package.js
@@ -16,7 +16,8 @@ Package.onUse(function(api) {
   api.use([
     'coffeescript',
     'check',
-    'underscore'
+    'underscore',
+    'ecmascript'
   ]);
 
   api.use([
@@ -34,9 +35,7 @@ Package.onUse(function(api) {
   ], {weak: true});
 
   api.addFiles([
-    'source/lib/underscore_deep_extend_mixin.js',
-    'source/namespace.coffee',
-    'source/helpers.coffee'
+    'source/namespace.coffee'
   ]);
 
   api.addFiles([
@@ -44,8 +43,10 @@ Package.onUse(function(api) {
   ], 'server');
 
   api.addFiles([
+    'source/lib/underscore_deep_extend_mixin.js',
     'source/object.coffee',
     'source/error.js',
+    'source/helpers.coffee',
     'source/struct.coffee',
     'source/injector.coffee',
     'source/injector_annotations.coffee',
@@ -61,6 +62,7 @@ Package.onTest(function(api) {
     'meteor',
     'coffeescript',
     'check',
+    'ecmascript',
     'space:base',
 
     // weak-dependencies

--- a/source/helpers.coffee
+++ b/source/helpers.coffee
@@ -1,8 +1,10 @@
 
 global = this
 
-class Space.CouldNotResolvePathError extends Error
-  constructor: (path) -> @message = "Could not resolve <#{path}>"
+class Space.CouldNotResolvePathError extends Space.Error
+  constructor: (path) ->
+    super
+    @message = "Could not resolve <#{path}>"
 
 # Resolves a (possibly nested) path to a global object
 # Returns the object or null (if not found)

--- a/source/module.coffee
+++ b/source/module.coffee
@@ -13,7 +13,6 @@ class Space.Module extends Space.Object
   Singletons: []
   injector: null
   _state: 'constructed'
-  _hasRunAfterInitializeHook: false
 
   constructor: ->
     super
@@ -44,25 +43,21 @@ class Space.Module extends Space.Object
 
     # Provide lifecycle hook before any initialization has been done
     @beforeInitialize?()
-    # After the required modules have been initialized, merge in the own
-    # configuration to give the chance for overwriting.
-    @Configuration = _.deepExtend(mergedConfig, @constructor::Configuration)
-    @injector.map('Configuration').to(@Configuration) unless isSubModule
     # Give every module access Npm
     if Meteor.isServer then @npm = Npm
-    # Inject required dependencies into this module
-    @injector.injectInto this
-    # Provide lifecycle hook after this module was configured and injected
-    @onInitialize?()
-    # Map classes that are declared as singletons
-    @injector.map(singleton).asSingleton() for singleton in @Singletons
-    @_state = 'initialized'
-    # After all modules in the tree have been configured etc. invoke last hook
-    if not isSubModule then @_runAfterInitializeHooks()
+    # Merge in own configuration to give the chance for overwriting.
+    @Configuration = _.deepExtend(mergedConfig, @constructor::Configuration)
+    # Top-level module
+    if not isSubModule
+      @injector.map('Configuration').to(@Configuration)
+      # Provide lifecycle hook after this module was configured and injected
+      @_runOnInitializeHooks()
+      # After all modules in the tree have been configured etc. invoke last hook
+      @_runAfterInitializeHooks()
 
   start: ->
     if @is('running') then return
-    @_runLifeCycleAction 'start', => @injector.create(singleton) for singleton in @Singletons
+    @_runLifeCycleAction 'start'
     @_state = 'running'
 
   reset: ->
@@ -116,12 +111,24 @@ class Space.Module extends Space.Object
     this["on#{Space.capitalizeString(action)}"]?()
     this["after#{Space.capitalizeString(action)}"]?()
 
+  _runOnInitializeHooks: ->
+    @_invokeActionOnRequiredModules '_runOnInitializeHooks'
+    # Never run this hook twice
+    if @is('constructed')
+      @_state = 'initializing'
+      # Inject required dependencies into this module
+      @injector.injectInto this
+      # Map classes that are declared as singletons
+      @injector.map(singleton).asSingleton() for singleton in @Singletons
+      @onInitialize?()
+
   _runAfterInitializeHooks: ->
     @_invokeActionOnRequiredModules '_runAfterInitializeHooks'
     # Never run this hook twice
-    if not @_hasRunAfterInitializeHook
+    if @is('initializing')
+      @injector.create(singleton) for singleton in @Singletons
       @afterInitialize?()
-      @_hasRunAfterInitializeHook = true
+      @_state = 'initialized'
 
   _invokeActionOnRequiredModules: (action) ->
     @app.modules[moduleId][action]?() for moduleId in @RequiredModules

--- a/source/module.coffee
+++ b/source/module.coffee
@@ -120,15 +120,18 @@ class Space.Module extends Space.Object
       @injector.injectInto this
       # Map classes that are declared as singletons
       @injector.map(singleton).asSingleton() for singleton in @Singletons
+      # Call custom lifecycle hook if existant
       @onInitialize?()
 
   _runAfterInitializeHooks: ->
     @_invokeActionOnRequiredModules '_runAfterInitializeHooks'
     # Never run this hook twice
     if @is('initializing')
-      @injector.create(singleton) for singleton in @Singletons
-      @afterInitialize?()
       @_state = 'initialized'
+      # Create singleton classes
+      @injector.create(singleton) for singleton in @Singletons
+      # Call custom lifecycle hook if existant
+      @afterInitialize?()
 
   _invokeActionOnRequiredModules: (action) ->
     @app.modules[moduleId][action]?() for moduleId in @RequiredModules

--- a/tests/unit/injector.unit.coffee
+++ b/tests/unit/injector.unit.coffee
@@ -19,7 +19,7 @@ describe 'Space.Injector', ->
       expect(@injector.get('myObject').test).to.equal testValue
 
     it 'throws error if mapping doesnt exist', ->
-      expect(=> @injector.get('blablub')).to.throw Error
+      expect(=> @injector.get('blablub')).to.throw new Space.CouldNotResolvePathError()
 
     it 'auto-maps singletons', ->
       first = @injector.get 'Space.Injector'
@@ -31,7 +31,7 @@ describe 'Space.Injector', ->
       expect(@injector.get('Space')).to.equal Space
 
     it 'throws if the auto-map value is undefined', ->
-      expect(=> @injector.get('NotExistingValue')).to.throw Error
+      expect(=> @injector.get('NotExistingValue')).to.throw
 
     it 'throws error if mapping would be overriden', ->
       @injector.map('test').to 'test'
@@ -41,7 +41,7 @@ describe 'Space.Injector', ->
     it 'can remove existing mappings', ->
       @injector.map('test').to 'test'
       @injector.remove 'test'
-      expect(=> @injector.get 'test').to.throw Error
+      expect(=> @injector.get 'test').to.throw
 
     it 'provides an alias for getting values', ->
       @injector.map('test').to 'test'


### PR DESCRIPTION
This PR fixes some problems related to the module initialization lifecycle. These changes were necessary for the upcoming refactoring of the `Space.eventSourcing.Snapshotter` singleton which configures itself.

* `onInitialize` is now called after the complete configuration has been merged and mapped.
* Singletons are now created right before the `afterInitialization` hook of each module
* The initialization hooks also use the `_state` property to flag the process