### PR TITLE
refactor all core apis to standard camel case

### DIFF
--- a/source/application.coffee
+++ b/source/application.coffee
@@ -1,7 +1,7 @@
 
 class Space.Application extends Space.Module
 
-  Configuration: {
+  configuration: {
     appId: null
   }
 
@@ -15,4 +15,4 @@ class Space.Application extends Space.Module
     @initialize this, options.injector ? new Space.Injector(), {}
 
   # Make it possible to override configuration (at any nested level)
-  configure: (options) -> _.deepExtend @Configuration, options
+  configure: (options) -> _.deepExtend @configuration, options

--- a/source/error.js
+++ b/source/error.js
@@ -1,8 +1,8 @@
 Space.Object.extend(Space, 'Error', _.extend({}, Error.prototype, {
   Constructor: function() {
-    var tmp = Error.apply(this, arguments);
+    let tmp = Error.apply(this, arguments);
     tmp.name = this.name = this.constructor.name;
-    if(tmp.message) this.message = tmp.message;
+    if (tmp.message) this.message = tmp.message;
     this.stack = tmp.stack;
   }
 }));

--- a/source/injector.coffee
+++ b/source/injector.coffee
@@ -1,7 +1,7 @@
 
 class Space.Injector
 
-  @ERRORS:
+  ERRORS:
     cannotMapUndefinedId: -> new Error 'Cannot map undefined value.'
     mappingExists: (id) -> new Error "A mapping for <#{id}> already exists."
     valueNotResolved: (path) -> new Error "Could not resolve <#{path}>."
@@ -14,11 +14,11 @@ class Space.Injector
   toString: -> 'Instance <Space.Injector>'
 
   map: (id, override) ->
-    if not id? then throw Injector.ERRORS.cannotMapUndefinedId()
+    if not id? then throw @ERRORS.cannotMapUndefinedId()
     mapping = @_mappings[id]
     # Avoid accidential override of existing mapping
     if mapping? and !override
-      throw Injector.ERRORS.mappingExists(id)
+      throw @ERRORS.mappingExists(id)
     else if mapping? and override
       mapping.markForOverride()
       return mapping
@@ -38,7 +38,7 @@ class Space.Injector
   remove: (id) -> delete @_mappings[id]
 
   get: (id, dependentObject=null) ->
-    if !id? then throw Injector.ERRORS.cannotGetValueForUndefined()
+    if !id? then throw @ERRORS.cannotGetValueForUndefined()
     if not @_mappings[id]? then @autoMap id
     dependency = @_mappings[id].provide(dependentObject)
     @injectInto dependency
@@ -88,7 +88,7 @@ class Space.Injector
 
   _resolveValue: (path) ->
     value = Space.resolvePath path
-    if not value? then throw Injector.ERRORS.valueNotResolved(path)
+    if not value? then throw @ERRORS.valueNotResolved(path)
     return value
 
 # ========= PRIVATE CLASSES ========== #

--- a/source/injector_annotations.coffee
+++ b/source/injector_annotations.coffee
@@ -1,11 +1,11 @@
 @Space.Dependency = (propertyName, dependencyId) ->
   (target) ->
-    target.prototype.Dependencies ?= {}
-    target.prototype.Dependencies[propertyName] = dependencyId
+    target.prototype.dependencies ?= {}
+    target.prototype.dependencies[propertyName] = dependencyId
     return target
 
 @Space.RequireModule = (moduleId) ->
   (target) ->
-    target.prototype.RequiredModules ?= []
-    target.prototype.RequiredModules.push moduleId
+    target.prototype.requiredModules ?= []
+    target.prototype.requiredModules.push moduleId
     return target

--- a/source/object.coffee
+++ b/source/object.coffee
@@ -87,7 +87,6 @@ class Space.Object
     # Assign the optional custom constructor for this class
     Parent = this
     Constructor = extension.Constructor ? -> Parent.apply(this, arguments)
-
     className = className.substr className.lastIndexOf('.') + 1
 
     # Create a named constructor for this class so that debugging

--- a/tests/integration/application_with_modules.spec.js
+++ b/tests/integration/application_with_modules.spec.js
@@ -17,7 +17,7 @@ describe('Building applications based on modules', function() {
     });
 
     Space.Application.create({
-      RequiredModules: ['FirstModule'],
+      requiredModules: ['FirstModule'],
       Dependencies: { testValue: 'testValue' },
       onInitialize: function() { testResult = this.testValue; }
     });
@@ -41,7 +41,7 @@ describe('Building applications based on modules', function() {
     });
 
     let app = Space.Application.create({
-      RequiredModules: ['FirstModule'],
+      requiredModules: ['FirstModule'],
       Dependencies: { moduleValue: 'moduleValue' },
       onInitialize: function() {
         this.injector.override('moduleValue').toStaticValue(appValue);

--- a/tests/integration/lifecycle_hooks.tests.js
+++ b/tests/integration/lifecycle_hooks.tests.js
@@ -53,8 +53,8 @@ describe("Space.base - Application lifecycle hooks", function() {
     this.appHooks = createLifeCycleHookSpies();
     // Create a app setup with two modules and use the spied apon hooks
     Space.Module.define('First', this.firstHooks);
-    Space.Module.define('Second', _.extend(this.secondHooks, { RequiredModules: ['First'] }));
-    this.app = Space.Application.create(_.extend(this.appHooks, { RequiredModules: ['Second'] }));
+    Space.Module.define('Second', _.extend(this.secondHooks, { requiredModules: ['First'] }));
+    this.app = Space.Application.create(_.extend(this.appHooks, { requiredModules: ['Second'] }));
   });
 
   it("runs the initialize hooks in correct order", function() {

--- a/tests/integration/module.regressions.js
+++ b/tests/integration/module.regressions.js
@@ -13,7 +13,7 @@ describe("Space.Module - regressions", function() {
     });
 
     Test.MyModule = Space.Module.extend(Test, 'MyModule', {
-      Singletons: ['Test.MySingleton'],
+      singletons: ['Test.MySingleton'],
       onInitialize() { this.injector.map('SomeLib').to(SomeLib); }
     });
 

--- a/tests/integration/requiring-modules.tests.js
+++ b/tests/integration/requiring-modules.tests.js
@@ -1,7 +1,7 @@
 
-describe("Space.base - Requiring modules in other modules and apps", function(){
+describe("Space.base - Requiring modules in other modules and apps", function() {
 
-  it("multiple modules should be able to require the same base module", function(){
+  it("multiple modules should be able to require the same base module", function() {
 
     Space.Module.define('BaseModule', {
       // Regression test -> this was invoked twice at some point
@@ -10,14 +10,14 @@ describe("Space.base - Requiring modules in other modules and apps", function(){
       }
     });
 
-    Space.Module.define('DependentModule1', { RequiredModules: ['BaseModule'] });
-    Space.Module.define('DependentModule2', { RequiredModules: ['BaseModule'] });
+    Space.Module.define('DependentModule1', { requiredModules: ['BaseModule'] });
+    Space.Module.define('DependentModule2', { requiredModules: ['BaseModule'] });
 
-    var MyApp = Space.Application.define('MyApp', {
-      RequiredModules: ['DependentModule1', 'DependentModule2']
+    const MyApp = Space.Application.define('MyApp', {
+      requiredModules: ['DependentModule1', 'DependentModule2']
     });
 
-    function appInit() { new MyApp(); }
+    let appInit = function() { return new MyApp(); };
     expect(appInit).to.not.throw(Error);
   });
 

--- a/tests/unit/application.unit.coffee
+++ b/tests/unit/application.unit.coffee
@@ -47,14 +47,14 @@ describe 'Space.Application', ->
     it 'merges configurations of all modules and user options', ->
       class GrandchildModule extends Space.Module
         @publish this, 'GrandchildModule'
-        Configuration: {
+        configuration: {
           grandchild: {
             toChange: 'grandchildChangeMe'
             toKeep: 'grandchildKeepMe'
           }
         }
         afterInitialize: ->
-          expect(@Configuration).toMatch {
+          expect(@configuration).toMatch {
             toChange: 'appChangeMe'
             toKeep: 'appKeepMe'
             child: {
@@ -69,16 +69,16 @@ describe 'Space.Application', ->
 
       class ChildModule extends Space.Module
         @publish this, 'ChildModule'
-        RequiredModules: ['GrandchildModule']
-        Configuration: {
+        requiredModules: ['GrandchildModule']
+        configuration: {
           child: {
             toChange: 'childChangeMe'
             toKeep: 'childKeepMe'
           }
         }
       class TestApp extends Space.Application
-        RequiredModules: ['ChildModule']
-        Configuration: {
+        requiredModules: ['ChildModule']
+        configuration: {
           toChange: 'appChangeMe'
           toKeep: 'appKeepMe'
         }
@@ -92,7 +92,7 @@ describe 'Space.Application', ->
           toChange: 'grandchildNewValue'
         }
       }
-      expect(app.injector.get 'Configuration').toMatch {
+      expect(app.injector.get 'configuration').toMatch {
         toChange: 'appNewValue'
         toKeep: 'appKeepMe'
         child: {

--- a/tests/unit/injector_annotations.unit.es6
+++ b/tests/unit/injector_annotations.unit.es6
@@ -1,32 +1,30 @@
-describe('Space.Injector annotations', function () {
+describe('Space.Injector annotations', function() {
 
-  describe('Dependency annotation', function () {
+  describe('Dependency annotation', function() {
 
-    it('adds the dependency to the Dependencies map', function () {
+    it('adds the dependency to the dependencies map', function() {
       @Space.Dependency('propertyName1', 'dependencyName1')
       @Space.Dependency('propertyName2', 'dependencyName2')
       class FixtureClass {}
 
-      expect(FixtureClass.prototype.Dependencies).to.deep.equal({
+      expect(FixtureClass.prototype.dependencies).to.deep.equal({
         'propertyName1': 'dependencyName1',
         'propertyName2': 'dependencyName2'
       });
     });
+  });
 
-  })
+  describe('RequireModule annotation', function() {
 
-  describe('RequireModule annotation', function () {
-
-    it('adds the required module to the RequiredModules array', function () {
+    it('adds the required module to the requiredModules array', function() {
       @Space.RequireModule('fooModule1')
       @Space.RequireModule('fooModule2')
       class FixtureClass {}
 
-      expect(FixtureClass.prototype.RequiredModules).to.contain('fooModule1');
-      expect(FixtureClass.prototype.RequiredModules).to.contain('fooModule2');
+      expect(FixtureClass.prototype.requiredModules).to.contain('fooModule1');
+      expect(FixtureClass.prototype.requiredModules).to.contain('fooModule2');
     });
 
   });
 
 });
-

--- a/tests/unit/module.unit.coffee
+++ b/tests/unit/module.unit.coffee
@@ -34,13 +34,13 @@ describe 'Space.Module', ->
 
     it 'sets required modules to empty array if none defined', ->
       module = new Space.Module()
-      expect(module.RequiredModules).to.be.instanceof Array
-      expect(module.RequiredModules).to.be.empty
+      expect(module.requiredModules).to.be.instanceof Array
+      expect(module.requiredModules).to.be.empty
 
     it 'leaves the defined required modules intact', ->
       testArray = []
-      module = Space.Module.create RequiredModules: testArray
-      expect(module.RequiredModules).to.equal testArray
+      module = Space.Module.create requiredModules: testArray
+      expect(module.requiredModules).to.equal testArray
 
     it 'sets the correct state', ->
       module = new Space.Module()
@@ -88,7 +88,7 @@ describe 'Space.Module - #initialize', ->
 
   it 'looks up required modules and adds them to the modules object', ->
     # make our SUT module require our fake modules
-    @module.RequiredModules = [@SubModule1.name, @SubModule2.name]
+    @module.requiredModules = [@SubModule1.name, @SubModule2.name]
     @module.initialize @app, @injector
     expect(@app.modules[@SubModule1.name]).to.equal @subModule1
     expect(@app.modules[@SubModule2.name]).to.equal @subModule2
@@ -96,7 +96,7 @@ describe 'Space.Module - #initialize', ->
   it 'initializes required modules when they are not yet initialized', ->
     sinon.spy @subModule1, 'initialize'
     sinon.spy @subModule2, 'initialize'
-    @module.RequiredModules = [@SubModule1.name, @SubModule2.name]
+    @module.requiredModules = [@SubModule1.name, @SubModule2.name]
     @module.initialize @app, @injector
     expect(@subModule1.initialize).to.have.been.called
     expect(@subModule2.initialize).to.have.been.called
@@ -104,7 +104,7 @@ describe 'Space.Module - #initialize', ->
   it 'doesnt initialize required modules if they are already initialized', ->
     @subModule1._state = 'initialized'
     sinon.spy @subModule1, 'initialize'
-    @module.RequiredModules = [@SubModule1.name]
+    @module.requiredModules = [@SubModule1.name]
     @module.initialize @app, @injector
     expect(@subModule1.initialize).not.to.have.been.called
 


### PR DESCRIPTION
As outlined in [this trello card](https://trello.com/c/8trbPA4O/21-refactor-to-camel-case-api-for-all-space-packages) i would like to take the opportunity to make a huge breaking change in our base APIs for the sake of standardization and making things more "javascript-like".