### PR TITLE
Feature/improve working with static apis

### DIFF
--- a/source/object.coffee
+++ b/source/object.coffee
@@ -107,6 +107,10 @@ class Space.Object
     mixins = extension.mixin
     delete extension.mixin
 
+    # Extract onExtending callback and avoid adding it to prototype
+    onExtendingCallback = extension.onExtending
+    delete extension.onExtending
+
     # Javascript prototypal inheritance "magic"
     Ctor = ->
       @constructor = Child
@@ -120,6 +124,9 @@ class Space.Object
 
     # Apply mixins
     if mixins? then Child.mixin(mixins)
+
+    # Invoke the onExtending callback after everything has been setup
+    onExtendingCallback?.call(Child)
 
     # Add the class to the namespace
     namespace?[className] = Child

--- a/source/object.coffee
+++ b/source/object.coffee
@@ -98,6 +98,11 @@ class Space.Object
     # Copy the static properties of this class over to the extended
     Child[key] = this[key] for key of this
 
+    # Copy over static class properties defined on the extension
+    if extension.statics?
+      _.extend Child, extension.statics
+      delete extension.statics
+
     # Extract mixins before they get added to prototype
     mixins = extension.mixin
     delete extension.mixin

--- a/source/object.coffee
+++ b/source/object.coffee
@@ -161,8 +161,8 @@ class Space.Object
       delete mixin.onDependenciesReady
 
     # Mixin static properties into the host class
-    _.extend(this, mixin.static) if mixin.static?
-    delete mixin.static
+    _.extend(this, mixin.statics) if mixin.statics?
+    delete mixin.statics
 
     # Give mixins the chance to do static setup when applied to the host class
     mixin.onMixinApplied?.call this

--- a/tests/unit/object.unit.coffee
+++ b/tests/unit/object.unit.coffee
@@ -6,39 +6,25 @@ describe 'Space.Object', ->
   describe 'extending', ->
 
     it 'creates and returns a subclass', ->
-
       Space.Object.extend(@namespace, 'MyClass')
       expect(@namespace.MyClass).to.extend Space.Object
 
     it 'applies the arguments to the super constructor', ->
-
       [first, second, third] = ['first', 2, {}]
       spy = sinon.spy()
-
       Space.Object.extend @namespace, 'Base', {
         Constructor: -> spy.apply this, arguments
       }
       @namespace.Base.extend(@namespace, 'Extended')
       instance = new @namespace.Extended first, second, third
-
       expect(spy).to.have.been.calledWithExactly first, second, third
       expect(spy).to.have.been.calledOn instance
 
     it 'allows to extend the prototype', ->
-
-      First = Space.Object.extend {
-        first: 1,
-        get: (property) -> @[property]
-      }
-
-      Second = First.extend {
-        second: 2,
-        get: -> First::get.apply this, arguments
-      }
-
+      First = Space.Object.extend first: 1, get: (property) -> @[property]
+      Second = First.extend second: 2, get: -> First::get.apply this, arguments
       class Third extends Second
         get: (property) -> super property
-
       instance = new Third()
       expect(instance.get('first')).to.equal 1
       expect(instance.get('second')).to.equal 2
@@ -54,9 +40,7 @@ describe 'Space.Object', ->
 
     it 'forwards any number of arguments to the constructor', ->
       Base = Space.Object.extend Constructor: (@first, @second) ->
-
       instance = Base.create 1, 2
-
       expect(instance.first).to.equal 1
       expect(instance.second).to.equal 2
 

--- a/tests/unit/object.unit.coffee
+++ b/tests/unit/object.unit.coffee
@@ -29,10 +29,17 @@ describe 'Space.Object', ->
       expect(instance.get('first')).to.equal 1
       expect(instance.get('second')).to.equal 2
 
-    it 'allows you to define static class properties', ->
-      myStatics = {}
-      MyClass = Space.Object.extend statics: { myStatics: myStatics }
-      expect(MyClass.myStatics).to.equal(myStatics)
+    describe "working with static class properties", ->
+
+      it 'allows you to define static class properties', ->
+        myStatics = {}
+        MyClass = Space.Object.extend statics: { myStatics: myStatics }
+        expect(MyClass.myStatics).to.equal(myStatics)
+
+      it 'provides an api for defining a callback while extending', ->
+        onExtendingSpy = sinon.spy()
+        MyClass = Space.Object.extend onExtending: onExtendingSpy
+        expect(onExtendingSpy).to.have.been.calledOn(MyClass)
 
   describe 'creating instances', ->
 

--- a/tests/unit/object.unit.coffee
+++ b/tests/unit/object.unit.coffee
@@ -122,3 +122,9 @@ describe 'Space.Object', ->
       myMixin = { onMixinApplied: sinon.spy() }
       MyClass = Space.Object.extend mixin: [myMixin]
       expect(myMixin.onMixinApplied).to.have.been.calledOn(MyClass)
+
+    it 'can be used to mixin static properties on to the class', ->
+      myMixin = statics: { myMethod: sinon.spy() }
+      MyClass = Space.Object.extend mixin: [myMixin]
+      MyClass.myMethod()
+      expect(myMixin.statics.myMethod).to.have.been.calledOn(MyClass)

--- a/tests/unit/object.unit.coffee
+++ b/tests/unit/object.unit.coffee
@@ -29,6 +29,11 @@ describe 'Space.Object', ->
       expect(instance.get('first')).to.equal 1
       expect(instance.get('second')).to.equal 2
 
+    it 'allows you to define static class properties', ->
+      myStatics = {}
+      MyClass = Space.Object.extend statics: { myStatics: myStatics }
+      expect(MyClass.myStatics).to.equal(myStatics)
+
   describe 'creating instances', ->
 
     it 'creates a new instance of given class', ->


### PR DESCRIPTION
This PR improves the way we can work with static class properties and setup work that has to be done statically (once) when the class is "created" via extending Space.Object / subclasses.

This basically gives us the missing meta-programming capabilities we had in Coffeescript.