### PR TITLE
Feature/logger improvements

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,0 +1,177 @@
+/**
+ * 0 - turn the rule off
+ * 1 - turn the rule on as a warning (doesn't affect exit code)
+ * 2 - turn the rule on as an error (exit code will be 1)
+ *
+ * Meteor Style Guide: https://github.com/meteor/meteor/wiki/Meteor-Style-Guide
+ *
+ */
+
+{
+  "parser": "babel-eslint",
+  "env": {
+    "browser": true,
+    "node": true
+  },
+  "ecmaFeatures": {
+    "arrowFunctions": true,
+    "blockBindings": true,
+    "classes": true,
+    "defaultParams": true,
+    "destructuring": true,
+    "forOf": true,
+    "generators": false,
+    "modules": true,
+    "objectLiteralComputedProperties": true,
+    "objectLiteralDuplicateProperties": false,
+    "objectLiteralShorthandMethods": true,
+    "objectLiteralShorthandProperties": true,
+    "spread": true,
+    "superInFunctions": true,
+    "templateStrings": true,
+    "jsx": true
+  },
+  "rules": {
+    /**
+     * Strict mode
+     */
+    // babel inserts "use strict"; for us
+    // http://eslint.org/docs/rules/strict
+    "strict": 0,
+
+    /**
+     * ES6
+     */
+    "no-var": 1,                     // http://eslint.org/docs/rules/no-var
+
+    /**
+     * Variables
+     */
+    "no-shadow": 2,                  // http://eslint.org/docs/rules/no-shadow
+    "no-shadow-restricted-names": 2, // http://eslint.org/docs/rules/no-shadow-restricted-names
+    "no-unused-vars": [2, {          // http://eslint.org/docs/rules/no-unused-vars
+      "vars": "local",
+      "args": "after-used"
+    }],
+    "no-use-before-define": [2, "nofunc"],       // http://eslint.org/docs/rules/no-use-before-define
+
+    /**
+     * Possible errors
+     */
+    "comma-dangle": [1, "never"],    // http://eslint.org/docs/rules/comma-dangle
+    "no-cond-assign": [2, "always"], // http://eslint.org/docs/rules/no-cond-assign
+    "no-console": 1,                 // http://eslint.org/docs/rules/no-console
+    "no-debugger": 1,                // http://eslint.org/docs/rules/no-debugger
+    "no-alert": 1,                   // http://eslint.org/docs/rules/no-alert
+    "no-constant-condition": 1,      // http://eslint.org/docs/rules/no-constant-condition
+    "no-dupe-keys": 2,               // http://eslint.org/docs/rules/no-dupe-keys
+    "no-duplicate-case": 2,          // http://eslint.org/docs/rules/no-duplicate-case
+    "no-empty": 2,                   // http://eslint.org/docs/rules/no-empty
+    "no-ex-assign": 2,               // http://eslint.org/docs/rules/no-ex-assign
+    "no-extra-boolean-cast": 0,      // http://eslint.org/docs/rules/no-extra-boolean-cast
+    "no-extra-semi": 2,              // http://eslint.org/docs/rules/no-extra-semi
+    "no-func-assign": 2,             // http://eslint.org/docs/rules/no-func-assign
+    "no-inner-declarations": 2,      // http://eslint.org/docs/rules/no-inner-declarations
+    "no-invalid-regexp": 2,          // http://eslint.org/docs/rules/no-invalid-regexp
+    "no-irregular-whitespace": 2,    // http://eslint.org/docs/rules/no-irregular-whitespace
+    "no-obj-calls": 2,               // http://eslint.org/docs/rules/no-obj-calls
+    "quote-props": [2, "as-needed", { "keywords": true, "unnecessary": false }], // http://eslint.org/docs/rules/quote-props (previously known as no-reserved-keys)
+    "no-sparse-arrays": 2,           // http://eslint.org/docs/rules/no-sparse-arrays
+    "no-unreachable": 2,             // http://eslint.org/docs/rules/no-unreachable
+    "use-isnan": 2,                  // http://eslint.org/docs/rules/use-isnan
+    "block-scoped-var": 0,           // http://eslint.org/docs/rules/block-scoped-var
+
+    /**
+     * Best practices
+     */
+    "consistent-return": 2,          // http://eslint.org/docs/rules/consistent-return
+    "curly": [2, "multi-line"],      // http://eslint.org/docs/rules/curly
+    "default-case": 2,               // http://eslint.org/docs/rules/default-case
+    "dot-notation": [2, {            // http://eslint.org/docs/rules/dot-notation
+      "allowKeywords": true
+    }],
+    "eqeqeq": 2,                     // http://eslint.org/docs/rules/eqeqeq
+    "guard-for-in": 2,               // http://eslint.org/docs/rules/guard-for-in
+    "no-caller": 2,                  // http://eslint.org/docs/rules/no-caller
+    //"no-else-return": 2,             // http://eslint.org/docs/rules/no-else-return
+    "no-eq-null": 2,                 // http://eslint.org/docs/rules/no-eq-null
+    "no-eval": 2,                    // http://eslint.org/docs/rules/no-eval
+    "no-extend-native": 2,           // http://eslint.org/docs/rules/no-extend-native
+    "no-extra-bind": 2,              // http://eslint.org/docs/rules/no-extra-bind
+    "no-fallthrough": 2,             // http://eslint.org/docs/rules/no-fallthrough
+    "no-floating-decimal": 2,        // http://eslint.org/docs/rules/no-floating-decimal
+    "no-implied-eval": 2,            // http://eslint.org/docs/rules/no-implied-eval
+    "no-lone-blocks": 2,             // http://eslint.org/docs/rules/no-lone-blocks
+    "no-loop-func": 2,               // http://eslint.org/docs/rules/no-loop-func
+    "no-multi-str": 2,               // http://eslint.org/docs/rules/no-multi-str
+    "no-native-reassign": 2,         // http://eslint.org/docs/rules/no-native-reassign
+    "no-new": 2,                     // http://eslint.org/docs/rules/no-new
+    "no-new-func": 2,                // http://eslint.org/docs/rules/no-new-func
+    "no-new-wrappers": 2,            // http://eslint.org/docs/rules/no-new-wrappers
+    "no-octal": 2,                   // http://eslint.org/docs/rules/no-octal
+    "no-octal-escape": 2,            // http://eslint.org/docs/rules/no-octal-escape
+    "no-param-reassign": 2,          // http://eslint.org/docs/rules/no-param-reassign
+    "no-proto": 2,                   // http://eslint.org/docs/rules/no-proto
+    "no-redeclare": 2,               // http://eslint.org/docs/rules/no-redeclare
+    "no-return-assign": 2,           // http://eslint.org/docs/rules/no-return-assign
+    "no-script-url": 2,              // http://eslint.org/docs/rules/no-script-url
+    "no-self-compare": 2,            // http://eslint.org/docs/rules/no-self-compare
+    "no-sequences": 2,               // http://eslint.org/docs/rules/no-sequences
+    "no-throw-literal": 2,           // http://eslint.org/docs/rules/no-throw-literal
+    "no-with": 2,                    // http://eslint.org/docs/rules/no-with
+    "radix": 2,                      // http://eslint.org/docs/rules/radix
+    "vars-on-top": 1,                // http://eslint.org/docs/rules/vars-on-top
+    "wrap-iife": [2, "any"],         // http://eslint.org/docs/rules/wrap-iife
+    "yoda": 2,                       // http://eslint.org/docs/rules/yoda
+    "max-len": [1, 200, 2],           // http://eslint.org/docs/rules/max-len
+
+    /**
+     * Style
+     */
+    "indent": [2, 2, {"VariableDeclarator": 2}],  // http://eslint.org/docs/rules/indent
+    "brace-style": [2,                            // http://eslint.org/docs/rules/brace-style
+      "1tbs", {
+        "allowSingleLine": true
+      }],
+    "camelcase": [2, {               // http://eslint.org/docs/rules/camelcase
+      "properties": "never"
+    }],
+    "comma-spacing": [2, {           // http://eslint.org/docs/rules/comma-spacing
+      "before": false,
+      "after": true
+    }],
+    "comma-style": [2, "last"],      // http://eslint.org/docs/rules/comma-style
+    "eol-last": 2,                   // http://eslint.org/docs/rules/eol-last
+    "func-names": 0,                 // http://eslint.org/docs/rules/func-names
+    "func-style": [2, "expression"], // http://eslint.org/docs/rules/func-style
+    "key-spacing": [2, {             // http://eslint.org/docs/rules/key-spacing
+      "beforeColon": false,
+      "afterColon": true
+    }],
+    "new-cap": [2, {                 // http://eslint.org/docs/rules/new-cap
+      "newIsCap": true,
+      "capIsNew": false
+    }],
+    "no-multiple-empty-lines": [2, { // http://eslint.org/docs/rules/no-multiple-empty-lines
+      "max": 2
+    }],
+    "no-nested-ternary": 2,          // http://eslint.org/docs/rules/no-nested-ternary
+    "no-new-object": 2,              // http://eslint.org/docs/rules/no-new-object
+    "no-array-constructor": 2,       // http://eslint.org/docs/rules/no-array-constructor
+    "no-spaced-func": 2,             // http://eslint.org/docs/rules/no-spaced-func
+    "no-trailing-spaces": 2,         // http://eslint.org/docs/rules/no-trailing-spaces
+    "no-underscore-dangle": 0,       // http://eslint.org/docs/rules/no-underscore-dangle
+    "one-var": [1, "never"],         // http://eslint.org/docs/rules/one-var
+    "semi": [2, "always"],           // http://eslint.org/docs/rules/semi
+    "semi-spacing": [2, {            // http://eslint.org/docs/rules/semi-spacing
+      "before": false,
+      "after": true
+    }],
+    "space-after-keywords": 2,       // http://eslint.org/docs/rules/space-after-keywords
+    "space-before-blocks": 2,        // http://eslint.org/docs/rules/space-before-blocks
+    "space-before-function-paren": [2, "never"], // http://eslint.org/docs/rules/space-before-function-paren
+    "space-infix-ops": 2,            // http://eslint.org/docs/rules/space-infix-ops
+    "space-return-throw-case": 2,    // http://eslint.org/docs/rules/space-return-throw-case
+    "spaced-comment": 2,            // http://eslint.org/docs/rules/spaced-comment (previously known as spaced-line-comment)
+  }
+}

--- a/source/configuration.js
+++ b/source/configuration.js
@@ -12,7 +12,7 @@ if (Meteor.isServer) {
     }
   });
 
-  // Pass down the
+  // Pass down to the client
   Meteor.settings = {
     "public": {
       log: {

--- a/source/configuration.js
+++ b/source/configuration.js
@@ -6,22 +6,18 @@ if (Meteor.isServer) {
   Space.getenv = getenv;
 
   Space.configuration = Space.getenv.multi({
-    sysLog: {
-      enabled: ['SPACE_SYSLOG_ENABLED', false, 'bool']
-    },
-    appLog: {
-      enabled: ['SPACE_APPLOG_ENABLED', false, 'bool']
+    log: {
+      enabled: ['SPACE_LOG_ENABLED', false, 'bool'],
+      minLevel: ['SPACE_LOG_MIN_LEVEL', 'info', 'string']
     }
   });
 
   // Pass down the
   Meteor.settings = {
     "public": {
-      sysLog: {
-        enabled: Space.configuration.sysLog.enabled
-      },
-      appLog: {
-        enabled: Space.configuration.appLog.enabled
+      log: {
+        enabled: Space.configuration.log.enabled,
+        minLevel: Space.configuration.log.minLevel
       }
     }
   };
@@ -33,11 +29,9 @@ if (Meteor.isServer) {
 if (Meteor.isClient) {
 
   Space.configuration = {
-    sysLog: {
-      enabled: Meteor.settings.public.sysLog.enabled
-    },
-    appLog: {
-      enabled: Meteor.settings.public.appLog.enabled
+    log: {
+      enabled: Meteor.settings.public.log.enabled,
+      minLevel: Meteor.settings.public.log.minLevel
     }
   };
 }

--- a/source/logger.js
+++ b/source/logger.js
@@ -33,16 +33,16 @@ Space.Logger = Space.Object.extend(Space, 'Logger', {
     }
   },
 
-  info(message) {
-    if (this.shouldLog()) this._logger.info(message);
+  info(message, meta) {
+    if (this.shouldLog()) this._logger.info(message, meta);
   },
 
-  warn(message) {
-    if (this.shouldLog()) this._logger.warn(message);
+  warn(message, meta) {
+    if (this.shouldLog()) this._logger.warn(message, meta);
   },
 
-  error(message) {
-    if (this.shouldLog()) this._logger.error(message);
+  error(message, meta) {
+    if (this.shouldLog()) this._logger.error(message, meta);
   },
 
   shouldLog() {

--- a/source/logger.js
+++ b/source/logger.js
@@ -14,7 +14,7 @@ Space.Object.extend(Space, 'Logger', {
     if (Meteor.isServer) {
       this._logger = new winston.Logger({
         transports: [
-          new (winston.transports.Console)({
+          new winston.transports.Console({
             colorize: true,
             prettyPrint: true
           })

--- a/source/logger.js
+++ b/source/logger.js
@@ -1,3 +1,5 @@
+let config = Space.configuration;
+
 if (Meteor.isServer) {
   winston = Npm.require('winston');
 }
@@ -5,10 +7,10 @@ if (Meteor.isServer) {
 Space.Logger = Space.Object.extend(Space, 'Logger', {
 
   _logger: null,
+  _minLevel: 6,
   _state: 'stopped',
 
   Constructor() {
-
     if (Meteor.isServer) {
       this._logger = new (winston.Logger)({
         transports: [
@@ -22,6 +24,16 @@ Space.Logger = Space.Object.extend(Space, 'Logger', {
     }
     if (Meteor.isClient) {
       this._logger = console;
+    }
+  },
+
+  setMinLevel(name) {
+    let newCode = this._levelCode(name)
+    if (this._minLevel !== newCode) {
+      this._minLevel = newCode;
+      if (Meteor.isServer) {
+        this._logger.transports.Console.level = name;
+      }
     }
   },
 
@@ -39,45 +51,59 @@ Space.Logger = Space.Object.extend(Space, 'Logger', {
 
   debug(message, meta) {
     check(message, String);
-    if (this._shouldLog()) this._logger.debug.apply(this, arguments);
+    if (this._isRunning()) this._logger.debug.apply(this, arguments);
   },
 
   info(message, meta) {
     check(message, String);
-    if (this._shouldLog()) this._logger.info.apply(this, arguments);
+    if (this._isRunning()) this._logger.info.apply(this, arguments);
   },
 
   notice(message, meta) {
     check(message, String);
-    if (this._shouldLog()) this._logger.notice.apply(this, arguments);
+    if (this._isRunning()) this._logger.notice.apply(this, arguments);
   },
 
   warning(message, meta) {
     check(message, String);
-    if (this._shouldLog()) this._logger.warning.apply(this, arguments);
+    if (this._isRunning()) this._logger.warning.apply(this, arguments);
   },
 
   error(message, meta) {
     check(message, String);
-    if (this._shouldLog()) this._logger.error.apply(this, arguments);
+    if (this._isRunning()) this._logger.error.apply(this, arguments);
   },
 
   crit(message, meta) {
     check(message, String);
-    if (this._shouldLog()) this._logger.crit.apply(this, arguments);
+    if (this._isRunning()) this._logger.crit.apply(this, arguments);
   },
 
   alert(message, meta) {
     check(message, String);
-    if (this._shouldLog()) this._logger.alert.apply(this, arguments);
+    if (this._isRunning()) this._logger.alert.apply(this, arguments);
   },
 
   emerg(message, meta) {
     check(message, String);
-    if (this._shouldLog()) this._logger.emerg.apply(this, arguments);
+    if (this._isRunning()) this._logger.emerg.apply(this, arguments);
   },
 
-  _shouldLog() {
+  _levelCode(name) {
+    let code = {
+      'emerg': 0,
+      'alert': 1,
+      'crit': 2,
+      'error': 3,
+      'warning': 4,
+      'notice': 5,
+      'info':6,
+      'debug': 7
+    }
+    return code[name];
+  },
+
+  _isRunning() {
     if (this._state === 'running') return true;
   }
 
@@ -86,6 +112,7 @@ Space.Logger = Space.Object.extend(Space, 'Logger', {
 // System log
 Space.log = new Space.Logger();
 
-if (Space.configuration.sysLog.enabled) {
+if (config.log.enabled) {
+  Space.log.setMinLevel(config.log.minLevel);
   Space.log.start();
 }

--- a/source/logger.js
+++ b/source/logger.js
@@ -1,4 +1,4 @@
-if (Meteor.isServer) {
+if(Meteor.isServer) {
   winston = Npm.require('winston');
 }
 
@@ -9,44 +9,47 @@ Space.Logger = Space.Object.extend(Space, 'Logger', {
 
   Constructor() {
 
-    if (Meteor.isServer) {
+    if(Meteor.isServer) {
       this._logger = new (winston.Logger)({
         transports: [
           new (winston.transports.Console)()
         ]
       });
     }
-    if (Meteor.isClient) {
+    if(Meteor.isClient) {
       this._logger = console;
     }
   },
 
   start() {
-    if (this._state === 'stopped') {
+    if(this._state === 'stopped') {
       this._state = 'running';
     }
   },
 
   stop() {
-    if (this._state === 'running') {
+    if(this._state === 'running') {
       this._state = 'stopped';
     }
   },
 
   info(message, meta) {
-    if (this.shouldLog()) this._logger.info(message, meta);
+    check(message, String)
+    if(this.shouldLog()) this._logger.info.apply(this, arguments);
   },
 
   warn(message, meta) {
-    if (this.shouldLog()) this._logger.warn(message, meta);
+    check(message, String)
+    if(this.shouldLog()) this._logger.warn.apply(this, arguments);
   },
 
   error(message, meta) {
-    if (this.shouldLog()) this._logger.error(message, meta);
+    check(message, String)
+    if(this.shouldLog()) this._logger.error.apply(this, arguments);
   },
 
   shouldLog() {
-    if (this._state === 'running') return true;
+    if(this._state === 'running') return true;
   }
 
 });
@@ -54,6 +57,6 @@ Space.Logger = Space.Object.extend(Space, 'Logger', {
 // System log
 Space.log = new Space.Logger();
 
-if (Space.configuration.sysLog.enabled) {
+if(Space.configuration.sysLog.enabled) {
   Space.log.start();
 }

--- a/source/logger.js
+++ b/source/logger.js
@@ -4,7 +4,7 @@ if (Meteor.isServer) {
   winston = Npm.require('winston');
 }
 
-Space.Logger = Space.Object.extend(Space, 'Logger', {
+Space.Object.extend(Space, 'Logger', {
 
   _logger: null,
   _minLevel: 6,
@@ -12,7 +12,7 @@ Space.Logger = Space.Object.extend(Space, 'Logger', {
 
   Constructor() {
     if (Meteor.isServer) {
-      this._logger = new (winston.Logger)({
+      this._logger = new winston.Logger({
         transports: [
           new (winston.transports.Console)({
             colorize: true,
@@ -28,11 +28,11 @@ Space.Logger = Space.Object.extend(Space, 'Logger', {
   },
 
   setMinLevel(name) {
-    let newCode = this._levelCode(name)
+    let newCode = this._levelCode(name);
     if (this._minLevel !== newCode) {
       this._minLevel = newCode;
       if (Meteor.isServer) {
-        this._logger.transports.Console.level = name;
+        this._logger.transports.console.level = name;
       }
     }
   },
@@ -49,42 +49,42 @@ Space.Logger = Space.Object.extend(Space, 'Logger', {
     }
   },
 
-  debug(message, meta) {
+  debug(message) {
     check(message, String);
     if (this._isRunning()) this._logger.debug.apply(this, arguments);
   },
 
-  info(message, meta) {
+  info(message) {
     check(message, String);
     if (this._isRunning()) this._logger.info.apply(this, arguments);
   },
 
-  notice(message, meta) {
+  notice(message) {
     check(message, String);
     if (this._isRunning()) this._logger.notice.apply(this, arguments);
   },
 
-  warning(message, meta) {
+  warning(message) {
     check(message, String);
     if (this._isRunning()) this._logger.warning.apply(this, arguments);
   },
 
-  error(message, meta) {
+  error(message) {
     check(message, String);
     if (this._isRunning()) this._logger.error.apply(this, arguments);
   },
 
-  crit(message, meta) {
+  crit(message) {
     check(message, String);
     if (this._isRunning()) this._logger.crit.apply(this, arguments);
   },
 
-  alert(message, meta) {
+  alert(message) {
     check(message, String);
     if (this._isRunning()) this._logger.alert.apply(this, arguments);
   },
 
-  emerg(message, meta) {
+  emerg(message) {
     check(message, String);
     if (this._isRunning()) this._logger.emerg.apply(this, arguments);
   },
@@ -97,9 +97,9 @@ Space.Logger = Space.Object.extend(Space, 'Logger', {
       'error': 3,
       'warning': 4,
       'notice': 5,
-      'info':6,
+      'info': 6,
       'debug': 7
-    }
+    };
     return code[name];
   },
 

--- a/source/logger.js
+++ b/source/logger.js
@@ -1,4 +1,4 @@
-if(Meteor.isServer) {
+if (Meteor.isServer) {
   winston = Npm.require('winston');
 }
 
@@ -9,47 +9,76 @@ Space.Logger = Space.Object.extend(Space, 'Logger', {
 
   Constructor() {
 
-    if(Meteor.isServer) {
+    if (Meteor.isServer) {
       this._logger = new (winston.Logger)({
         transports: [
-          new (winston.transports.Console)()
+          new (winston.transports.Console)({
+            colorize: true,
+            prettyPrint: true
+          })
         ]
       });
+      this._logger.setLevels(winston.config.syslog.levels);
     }
-    if(Meteor.isClient) {
+    if (Meteor.isClient) {
       this._logger = console;
     }
   },
 
   start() {
-    if(this._state === 'stopped') {
+    if (this._state === 'stopped') {
       this._state = 'running';
     }
   },
 
   stop() {
-    if(this._state === 'running') {
+    if (this._state === 'running') {
       this._state = 'stopped';
     }
   },
 
-  info(message, meta) {
-    check(message, String)
-    if(this.shouldLog()) this._logger.info.apply(this, arguments);
+  debug(message, meta) {
+    check(message, String);
+    if (this._shouldLog()) this._logger.debug.apply(this, arguments);
   },
 
-  warn(message, meta) {
-    check(message, String)
-    if(this.shouldLog()) this._logger.warn.apply(this, arguments);
+  info(message, meta) {
+    check(message, String);
+    if (this._shouldLog()) this._logger.info.apply(this, arguments);
+  },
+
+  notice(message, meta) {
+    check(message, String);
+    if (this._shouldLog()) this._logger.notice.apply(this, arguments);
+  },
+
+  warning(message, meta) {
+    check(message, String);
+    if (this._shouldLog()) this._logger.warning.apply(this, arguments);
   },
 
   error(message, meta) {
-    check(message, String)
-    if(this.shouldLog()) this._logger.error.apply(this, arguments);
+    check(message, String);
+    if (this._shouldLog()) this._logger.error.apply(this, arguments);
   },
 
-  shouldLog() {
-    if(this._state === 'running') return true;
+  crit(message, meta) {
+    check(message, String);
+    if (this._shouldLog()) this._logger.crit.apply(this, arguments);
+  },
+
+  alert(message, meta) {
+    check(message, String);
+    if (this._shouldLog()) this._logger.alert.apply(this, arguments);
+  },
+
+  emerg(message, meta) {
+    check(message, String);
+    if (this._shouldLog()) this._logger.emerg.apply(this, arguments);
+  },
+
+  _shouldLog() {
+    if (this._state === 'running') return true;
   }
 
 });
@@ -57,6 +86,6 @@ Space.Logger = Space.Object.extend(Space, 'Logger', {
 // System log
 Space.log = new Space.Logger();
 
-if(Space.configuration.sysLog.enabled) {
+if (Space.configuration.sysLog.enabled) {
   Space.log.start();
 }

--- a/tests/unit/logger.tests.js
+++ b/tests/unit/logger.tests.js
@@ -21,79 +21,88 @@ describe("Space.Logger", function () {
     expect(this.log._logger.info).to.be.calledWithExactly(message);
   });
 
-  it("it can log a debug message to the output channel", function () {
+  it("it can log a debug message to the output channel when min level is equal but not less", function () {
     this.log.start();
+    this.log.setMinLevel('debug');
     this.log._logger.debug = sinon.spy();
-    let message = 'My Log Message';
+    let message = 'My log message';
     this.log.debug(message);
-    expect(this.log._logger.debug).to.be.calledWithExactly(message);
+    expect(this.log._logger.debug).to.be.calledWithExactly(message)
+    this.log._logger.debug = sinon.spy();
+    this.log.setMinLevel('info');
+    this.log.debug(message);
+    expect(this.log._logger.debug).not.to.be.called;
   });
 
-  it("it can log an info message to the output channel", function () {
+  it("it can log an info message to the output channel when min level is equal or higher, but not less", function () {
     this.log.start();
+    this.log.setMinLevel('info');
     this.log._logger.info = sinon.spy();
-    let message = 'My Log Message';
+    this.log._logger.debug = sinon.spy();
+    let message = 'My log message';
     this.log.info(message);
     expect(this.log._logger.info).to.be.calledWithExactly(message);
+    expect(this.log._logger.debug).not.to.be.called;
+    this.log._logger.info = sinon.spy();
+    this.log.setMinLevel('warning');
+    this.log.info(message);
+    expect(this.log._logger.info).not.to.be.called;
   });
 
-  it("it can log a notice message to the output channel", function () {
+  it.server("it can log a warning message to the output channel when min level is equal or higher, but not less", function () {
     this.log.start();
-    this.log._logger.notice = sinon.spy();
-    let message = 'My Log Message';
-    this.log.notice(message);
-    expect(this.log._logger.notice).to.be.calledWithExactly(message);
-  });
-
-  it("it can log a warning message to the output channel", function () {
-    this.log.start();
+    this.log.setMinLevel('warning');
     this.log._logger.warning = sinon.spy();
-    let message = 'My Log Message';
+    this.log._logger.info = sinon.spy();
+    let message = 'My log message';
     this.log.warning(message);
     expect(this.log._logger.warning).to.be.calledWithExactly(message);
+    expect(this.log._logger.info).not.to.be.called;
+    this.log._logger.warning = sinon.spy();
+    this.log.setMinLevel('error');
+    this.log.warning(message);
+    expect(this.log._logger.warning).not.to.be.called;
   });
 
-  it("it can log an error message to the output channel", function () {
+  it.client("it can log a warning message to the output channel when min level is equal or higher, but not less", function () {
     this.log.start();
+    this.log.setMinLevel('warning');
+    this.log._logger.warn = sinon.spy();
+    this.log._logger.info = sinon.spy();
+    let message = 'My log message';
+    this.log.warning(message);
+    expect(this.log._logger.warn).to.be.calledWithExactly(message);
+    expect(this.log._logger.info).not.to.be.called;
+    this.log._logger.warn = sinon.spy();
+    this.log.setMinLevel('error');
+    this.log.warning(message);
+    expect(this.log._logger.warn).not.to.be.called;
+  });
+
+  it("it can log an error message to the output channel when min level is equal", function () {
+    this.log.start();
+    this.log.setMinLevel('error');
     this.log._logger.error = sinon.spy();
-    let message = 'My Log Message';
+    this.log._logger.info = sinon.spy();
+    let message = 'My log message';
     this.log.error(message);
     expect(this.log._logger.error).to.be.calledWithExactly(message);
-  });
-
-  it("it can log a crit message to the output channel", function () {
-    this.log.start();
-    this.log._logger.crit = sinon.spy();
-    let message = 'My Log Message';
-    this.log.crit(message);
-    expect(this.log._logger.crit).to.be.calledWithExactly(message);
-  });
-
-  it("it can log an alert message to the output channel", function () {
-    this.log.start();
-    this.log._logger.alert = sinon.spy();
-    let message = 'My Log Message';
-    this.log.alert(message);
-    expect(this.log._logger.alert).to.be.calledWithExactly(message);
-  });
-
-  it("it can log an emerg message to the output channel", function () {
-    this.log.start();
-    this.log._logger.emerg = sinon.spy();
-    let message = 'My Log Message';
-    this.log.emerg(message);
-    expect(this.log._logger.emerg).to.be.calledWithExactly(message);
+    expect(this.log._logger.info).not.to.be.called;
+    this.log._logger.info = sinon.spy();
+    this.log.setMinLevel('debug');
+    this.log.error(message);
+    expect(this.log._logger.error).to.be.calledWithExactly(message);
   });
 
   it("allows logging output to be stopped", function () {
     this.log._logger.info = sinon.spy();
     this.log.start();
-    expect(this.log._state).to.equal('running');
+    expect(this.log._is('running')).to.be.true;
     this.log.stop();
     let message = 'My Log Message';
     this.log.info(message);
     expect(this.log._logger.info).not.to.be.called;
-    expect(this.log._state).to.equal('stopped');
+    expect(this.log._is('stopped')).to.be.true;
   });
 
 });

--- a/tests/unit/logger.tests.js
+++ b/tests/unit/logger.tests.js
@@ -1,19 +1,23 @@
-describe("Space.Logger", function () {
+describe("Space.Logger", function() {
 
-  beforeEach(function(){
+  beforeEach(function() {
     this.log = new Space.Logger();
   });
 
-  it('extends Space.Object', function(){
+  afterEach(function() {
+    this.log.stop();
+  });
+
+  it('extends Space.Object', function() {
     expect(Space.Logger).to.extend(Space.Object);
   });
 
-  it("is available of both client and server", function () {
+  it("is available of both client and server", function() {
     if (Meteor.isServer || Meteor.isClient)
       expect(this.log).to.be.instanceOf(Space.Logger);
   });
 
-  it("only logs after starting", function () {
+  it("only logs after starting", function() {
     this.log.start();
     this.log._logger.info = sinon.spy();
     let message = 'My Log Message';
@@ -21,20 +25,20 @@ describe("Space.Logger", function () {
     expect(this.log._logger.info).to.be.calledWithExactly(message);
   });
 
-  it("it can log a debug message to the output channel when min level is equal but not less", function () {
+  it("it can log a debug message to the output channel when min level is equal but not less", function() {
     this.log.start();
     this.log.setMinLevel('debug');
     this.log._logger.debug = sinon.spy();
     let message = 'My log message';
     this.log.debug(message);
-    expect(this.log._logger.debug).to.be.calledWithExactly(message)
+    expect(this.log._logger.debug).to.be.calledWithExactly(message);
     this.log._logger.debug = sinon.spy();
     this.log.setMinLevel('info');
     this.log.debug(message);
     expect(this.log._logger.debug).not.to.be.called;
   });
 
-  it("it can log an info message to the output channel when min level is equal or higher, but not less", function () {
+  it("it can log an info message to the output channel when min level is equal or higher, but not less", function() {
     this.log.start();
     this.log.setMinLevel('info');
     this.log._logger.info = sinon.spy();
@@ -49,7 +53,7 @@ describe("Space.Logger", function () {
     expect(this.log._logger.info).not.to.be.called;
   });
 
-  it.server("it can log a warning message to the output channel when min level is equal or higher, but not less", function () {
+  it.server("it can log a warning message to the output channel when min level is equal or higher, but not less", function() {
     this.log.start();
     this.log.setMinLevel('warning');
     this.log._logger.warning = sinon.spy();
@@ -64,7 +68,7 @@ describe("Space.Logger", function () {
     expect(this.log._logger.warning).not.to.be.called;
   });
 
-  it.client("it can log a warning message to the output channel when min level is equal or higher, but not less", function () {
+  it.client("it can log a warning message to the output channel when min level is equal or higher, but not less", function() {
     this.log.start();
     this.log.setMinLevel('warning');
     this.log._logger.warn = sinon.spy();
@@ -79,7 +83,7 @@ describe("Space.Logger", function () {
     expect(this.log._logger.warn).not.to.be.called;
   });
 
-  it("it can log an error message to the output channel when min level is equal", function () {
+  it("it can log an error message to the output channel when min level is equal", function() {
     this.log.start();
     this.log.setMinLevel('error');
     this.log._logger.error = sinon.spy();
@@ -94,7 +98,7 @@ describe("Space.Logger", function () {
     expect(this.log._logger.error).to.be.calledWithExactly(message);
   });
 
-  it("allows logging output to be stopped", function () {
+  it("allows logging output to be stopped", function() {
     this.log._logger.info = sinon.spy();
     this.log.start();
     expect(this.log._is('running')).to.be.true;

--- a/tests/unit/logger.tests.js
+++ b/tests/unit/logger.tests.js
@@ -1,56 +1,96 @@
 describe("Space.Logger", function () {
 
   beforeEach(function(){
-    this.log = new Space.Logger()
+    this.log = new Space.Logger();
   });
 
   it('extends Space.Object', function(){
-    expect(Space.Logger).to.extend(Space.Object)
+    expect(Space.Logger).to.extend(Space.Object);
   });
 
   it("is available of both client and server", function () {
-    if(Meteor.isServer || Meteor.isClient)
+    if (Meteor.isServer || Meteor.isClient)
       expect(this.log).to.be.instanceOf(Space.Logger);
   });
 
   it("only logs after starting", function () {
-    this.log.start()
-    this.log._logger.info = sinon.spy()
-    let message = 'My Log Message'
+    this.log.start();
+    this.log._logger.info = sinon.spy();
+    let message = 'My Log Message';
     this.log.info(message);
     expect(this.log._logger.info).to.be.calledWithExactly(message);
+  });
+
+  it("it can log a debug message to the output channel", function () {
+    this.log.start();
+    this.log._logger.debug = sinon.spy();
+    let message = 'My Log Message';
+    this.log.debug(message);
+    expect(this.log._logger.debug).to.be.calledWithExactly(message);
   });
 
   it("it can log an info message to the output channel", function () {
-    this.log.start()
-    this.log._logger.info = sinon.spy()
-    let message = 'My Log Message'
+    this.log.start();
+    this.log._logger.info = sinon.spy();
+    let message = 'My Log Message';
     this.log.info(message);
     expect(this.log._logger.info).to.be.calledWithExactly(message);
   });
 
-  it("it can log a warn message to the output channel", function () {
-    this.log.start()
-    this.log._logger.warn = sinon.spy()
-    let message = 'My Log Message'
-    this.log.warn(message);
-    expect(this.log._logger.warn).to.be.calledWithExactly(message);
+  it("it can log a notice message to the output channel", function () {
+    this.log.start();
+    this.log._logger.notice = sinon.spy();
+    let message = 'My Log Message';
+    this.log.notice(message);
+    expect(this.log._logger.notice).to.be.calledWithExactly(message);
+  });
+
+  it("it can log a warning message to the output channel", function () {
+    this.log.start();
+    this.log._logger.warning = sinon.spy();
+    let message = 'My Log Message';
+    this.log.warning(message);
+    expect(this.log._logger.warning).to.be.calledWithExactly(message);
   });
 
   it("it can log an error message to the output channel", function () {
-    this.log.start()
-    this.log._logger.error = sinon.spy()
-    let message = 'My Log Message'
+    this.log.start();
+    this.log._logger.error = sinon.spy();
+    let message = 'My Log Message';
     this.log.error(message);
     expect(this.log._logger.error).to.be.calledWithExactly(message);
   });
 
+  it("it can log a crit message to the output channel", function () {
+    this.log.start();
+    this.log._logger.crit = sinon.spy();
+    let message = 'My Log Message';
+    this.log.crit(message);
+    expect(this.log._logger.crit).to.be.calledWithExactly(message);
+  });
+
+  it("it can log an alert message to the output channel", function () {
+    this.log.start();
+    this.log._logger.alert = sinon.spy();
+    let message = 'My Log Message';
+    this.log.alert(message);
+    expect(this.log._logger.alert).to.be.calledWithExactly(message);
+  });
+
+  it("it can log an emerg message to the output channel", function () {
+    this.log.start();
+    this.log._logger.emerg = sinon.spy();
+    let message = 'My Log Message';
+    this.log.emerg(message);
+    expect(this.log._logger.emerg).to.be.calledWithExactly(message);
+  });
+
   it("allows logging output to be stopped", function () {
-    this.log._logger.info = sinon.spy()
-    this.log.start()
+    this.log._logger.info = sinon.spy();
+    this.log.start();
     expect(this.log._state).to.equal('running');
-    this.log.stop()
-    let message = 'My Log Message'
+    this.log.stop();
+    let message = 'My Log Message';
     this.log.info(message);
     expect(this.log._logger.info).not.to.be.called;
     expect(this.log._state).to.equal('stopped');


### PR DESCRIPTION
Previously there were two instances of Space.Logger being created, one for low level logging and the other created and mapped when the top-level module was initiated. This was being done to isolate the low level lifecycle log events, but there’s a better way to do this using logging levels.

Now the top-level module just maps the Space.log instance to ‘log’ instead of creating a new one and we can use 8 levels to categorise the log message.

**Breaking Changes**:
- SPACE_LOG_ENABLED replaces SPACE_SYSLOG_ENABLED,
- SPACE_APPLOG_ENABLED removed from spec

**New config options**
- SPACE_LOG_MIN_LEVEL restricts logging to types above one of the
following: `debug`, `info`, `notice`, `warning`, `error`, `crit`, `alert`, `emerg`

I still need to:
- [x] Add tests to cover the level logic
- [x] Handle client side level restriction