### PR TITLE
improves injection mapping error handling

### DIFF
--- a/source/error.js
+++ b/source/error.js
@@ -1,8 +1,16 @@
-Space.Object.extend(Space, 'Error', _.extend({}, Error.prototype, {
-  Constructor: function() {
-    let tmp = Error.apply(this, arguments);
-    tmp.name = this.name = this.constructor.name;
-    if (tmp.message) this.message = tmp.message;
-    this.stack = tmp.stack;
-  }
-}));
+let IntermediateInheritor = function() {};
+IntermediateInheritor.prototype = Error.prototype;
+
+Space.Error = function() {
+  let tmp = Error.apply(this, arguments);
+  tmp.name = this.name = this.constructor.name;
+  if (tmp.message) this.message = tmp.message;
+  this.stack = tmp.stack;
+  return this;
+};
+
+Space.Error.prototype = new IntermediateInheritor();
+
+Space.Error.extend = Space.Object.extend;
+
+Space.Error.__keepToStringMethod__ = true;

--- a/source/helpers.coffee
+++ b/source/helpers.coffee
@@ -1,10 +1,9 @@
 
 global = this
 
-class Space.CouldNotResolvePathError extends Space.Error
-  constructor: (path) ->
-    super
-    @message = "Could not resolve <#{path}>"
+Space.Error.extend(Space, 'CouldNotResolvePathError', {
+  Constructor: (path) -> Space.Error.call(this, "'#{path}'")
+})
 
 # Resolves a (possibly nested) path to a global object
 # Returns the object or null (if not found)

--- a/source/injector.coffee
+++ b/source/injector.coffee
@@ -1,11 +1,14 @@
 
+Space.Error.extend(Space, 'InjectionError')
+
 class Space.Injector
 
-  ERRORS:
-    cannotMapUndefinedId: -> new Error 'Cannot map undefined value.'
-    mappingExists: (id) -> new Error "A mapping for <#{id}> already exists."
-    valueNotResolved: (path) -> new Error "Could not resolve <#{path}>."
-    cannotGetValueForUndefined: -> new Error "Cannot get value for undefined."
+  ERRORS: {
+    cannotMapUndefinedId: -> 'Cannot map <null> or <undefined>.'
+    mappingExists: (id) -> "<#{id}> would be overwritten. Use <Injector::override> for that."
+    noMappingFound: -> "no mapping found"
+    cannotGetValueForUndefined: -> "Cannot get injection mapping for <undefined>."
+  }
 
   constructor: (providers) ->
     @_mappings = {}
@@ -14,11 +17,12 @@ class Space.Injector
   toString: -> 'Instance <Space.Injector>'
 
   map: (id, override) ->
-    if not id? then throw @ERRORS.cannotMapUndefinedId()
+    if not id?
+      throw new Space.InjectionError(@ERRORS.cannotMapUndefinedId())
     mapping = @_mappings[id]
     # Avoid accidential override of existing mapping
     if mapping? and !override
-      throw @ERRORS.mappingExists(id)
+      throw new Space.InjectionError(@ERRORS.mappingExists(id))
     else if mapping? and override
       mapping.markForOverride()
       return mapping
@@ -26,20 +30,15 @@ class Space.Injector
       @_mappings[id] = new Mapping id, @_providers
       return @_mappings[id]
 
-  autoMap: (id) ->
-    value = @_resolveValue id
-    if _.isFunction(value)
-      @map(id).toSingleton value
-    else
-      @map(id).to value
-
   override: (id) -> @map id, true
 
   remove: (id) -> delete @_mappings[id]
 
   get: (id, dependentObject=null) ->
-    if !id? then throw @ERRORS.cannotGetValueForUndefined()
-    if not @_mappings[id]? then @autoMap id
+    if !id?
+      throw new Space.InjectionError(@ERRORS.cannotGetValueForUndefined())
+    if not @_mappings[id]?
+      throw new Space.InjectionError(@ERRORS.noMappingFound())
     dependency = @_mappings[id].provide(dependentObject)
     @injectInto dependency
     return dependency
@@ -61,7 +60,13 @@ class Space.Injector
     # Get flat map of dependencies (possibly inherited)
     dependencies = @_mapDependencies value
     # Inject into dependencies to create the object graph
-    value[key] ?= @get(id, value) for key, id of dependencies
+    for key, id of dependencies
+      try
+        value[key] ?= @get(id, value)
+      catch error
+        error.message += " for {#{key}: '#{id}'} in <#{value}>. Did you forget
+                           to map #{id} in your application?"
+        throw error
     # Notify when dependencies are ready
     if value.onDependenciesReady? then value.onDependenciesReady()
 
@@ -86,10 +91,7 @@ class Space.Injector
     deps[key] = id for key, id of value.dependencies
     return deps
 
-  _resolveValue: (path) ->
-    value = Space.resolvePath path
-    if not value? then throw @ERRORS.valueNotResolved(path)
-    return value
+  _resolveValue: (path) -> Space.resolvePath path
 
 # ========= PRIVATE CLASSES ========== #
 
@@ -127,7 +129,12 @@ class Mapping
   _setup: (provider) ->
     return (value) => # We are inside an API call like injector.map('this').to('that')
       # Set the provider of this mapping to what the API user chose
-      @_provider = new provider @_id, value
+      try
+        @_provider = new provider @_id, value
+      catch error
+        error.message += " could not be found! Maybe you forgot to
+                           include a file in package.js?"
+        throw error
       # Override the dependency in all dependent objects if this mapping is flagged
       if @_overrideInDependents
         # Get the value from the provider

--- a/source/object.coffee
+++ b/source/object.coffee
@@ -119,6 +119,10 @@ class Space.Object
     Child.prototype = new Ctor()
     Child.__super__ = Parent.prototype
 
+    # Return the class name with #toString by default
+    unless Parent.__keepToStringMethod__
+      Child.prototype.toString = -> className
+
     # Copy the extension over to the class prototype
     Child.prototype[key] = extension[key] for key of extension
 

--- a/tests/unit/error.tests.js
+++ b/tests/unit/error.tests.js
@@ -1,25 +1,29 @@
-describe("Space.Error", function () {
+describe("Space.Error", function() {
 
   MyError = Space.Error.extend('MyError', {
     message: 'The default message for this error'
   });
 
-  it("throws the prototype message by default", function () {
-    function throwWithDefaultMessage() {
+  it("is an instance of error", function() {
+    expect(new MyError()).to.instanceof(Error);
+  });
+
+  it("throws the prototype message by default", function() {
+    let throwWithDefaultMessage = function() {
       throw new MyError();
-    }
+    };
     expect(throwWithDefaultMessage).to.throw(MyError.prototype.message);
   });
 
-  it("takes an optional message during construction", function () {
-    var myMessage = 'this is a custom message';
-    function throwWithCustomMessage() {
+  it("takes an optional message during construction", function() {
+    let myMessage = 'this is a custom message';
+    let throwWithCustomMessage = function() {
       throw new MyError(myMessage);
-    }
+    };
     expect(throwWithCustomMessage).to.throw(myMessage);
   });
 
-  it("includes a stack trace", function () {
+  it("includes a stack trace", function() {
     error = new MyError();
     expect(error.stack).to.be.a.string;
   });

--- a/tests/unit/injector.unit.coffee
+++ b/tests/unit/injector.unit.coffee
@@ -19,19 +19,10 @@ describe 'Space.Injector', ->
       expect(@injector.get('myObject').test).to.equal testValue
 
     it 'throws error if mapping doesnt exist', ->
-      expect(=> @injector.get('blablub')).to.throw new Space.CouldNotResolvePathError()
-
-    it 'auto-maps singletons', ->
-      first = @injector.get 'Space.Injector'
-      second = @injector.get 'Space.Injector'
-      expect(first).to.be.instanceof Space.Injector
-      expect(first).to.equal second
-
-    it 'auto-maps static values', ->
-      expect(@injector.get('Space')).to.equal Space
-
-    it 'throws if the auto-map value is undefined', ->
-      expect(=> @injector.get('NotExistingValue')).to.throw
+      id = 'blablub'
+      expect(=> @injector.get(id)).to.throw(
+        @injector.ERRORS.noMappingFound(id).message
+      )
 
     it 'throws error if mapping would be overriden', ->
       @injector.map('test').to 'test'
@@ -55,8 +46,8 @@ describe 'Space.Injector', ->
       expect(@injector.get('TestClass')).to.be.instanceof TestClass
 
     it 'throws error if you try to map undefined', ->
-      expect(=> @injector.map(undefined)).to.throw 'Cannot map undefined value.'
-      expect(=> @injector.map(null)).to.throw 'Cannot map undefined value.'
+      expect(=> @injector.map(undefined)).to.throw @injector.ERRORS.cannotMapUndefinedId()
+      expect(=> @injector.map(null)).to.throw @injector.ERRORS.cannotMapUndefinedId()
 
   describe 'overriding mappings', ->
 


### PR DESCRIPTION
This PR introduces some kick-ass improvements regarding error handling / messages when working with dependency injection / mappings:

- Now throws real errors again (not `Uncaught [Object Object]` uarrrgh …)
- Throws ultra-helpful error messages like `Uncaught InjectionError: no mapping found for {users: 'Space.accountsUi.UsersDAO'} in <UsersStore>. Did you forget to map Space.accountsUi.UsersDAO in your application?` now!
- Removed auto-mapping feature completely -> **this might be a breaking change in other packages!!** but it should be best practice to map everything explicitly anyway!