### PR TITLE
refactor struct constructor into overridable methods

### DIFF
--- a/source/error.js
+++ b/source/error.js
@@ -37,6 +37,8 @@ _.extend(Space.Error.prototype, {
     return data;
   },
   toPlainObject: Space.Struct.prototype.toPlainObject,
+  _checkFields: Space.Struct.prototype._checkFields,
+  _assignData: Space.Struct.prototype._assignData,
   _getMixinCallbacks: Space.Object.prototype._getMixinCallbacks,
   onDependenciesReady: Space.Object.prototype.onDependenciesReady
 });

--- a/source/struct.coffee
+++ b/source/struct.coffee
@@ -3,13 +3,9 @@ class Space.Struct extends Space.Object
 
   @fields: {}
 
-  constructor: (data) ->
-    fields = @fields()
-    data ?= {}
-    # Use the fields configuration to check given data during runtime
-    check data, fields
-    # Copy data to instance
-    @[key] = data[key] for key of data
+  constructor: (data={}) ->
+    @_checkFields(data)
+    @_assignData(data)
 
   fields: -> _.clone(@constructor.fields) ? {}
 
@@ -17,3 +13,9 @@ class Space.Struct extends Space.Object
     copy = {}
     copy[key] = @[key] for key of @fields() when @[key] != undefined
     return copy
+
+  # Use the fields configuration to check given data during runtime
+  _checkFields: (data) -> check data, @fields()
+
+  # Copy data to instance
+  _assignData: (data) -> @[key] = data[key] for key of data


### PR DESCRIPTION
This PR makes it easier to override specific functionality of `Space.Struct` by moving all the logic into dedicated protected methods instead of doing it in the constructor (might be a good pattern in general!)