### PR TITLE
fixes bugs in module config and reset

### DIFF
--- a/source/lib/underscore_deep_extend_mixin.js
+++ b/source/lib/underscore_deep_extend_mixin.js
@@ -1,99 +1,17 @@
-/*  Copyright (C) 2012-2014  Kurt Milam - http://xioup.com | Source: https://gist.github.com/1868955
- *
- *  Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
- *  The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
- *
- *  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-**/
+// Deep object extend for underscore
+// As found on http://stackoverflow.com/a/29563346
 
-// Based conceptually on the _.extend() function in underscore.js ( see http://documentcloud.github.com/underscore/#extend for more details )
-
-function deepExtend(obj) {
-  var parentRE = /#{\s*?_\s*?}/,
-  slice = Array.prototype.slice;
-
-  _.each(slice.call(arguments, 1), function(source) {
-    for (var prop in source) {
-      if (_.isUndefined(obj[prop]) || _.isFunction(obj[prop]) || _.isNull(source[prop]) || _.isDate(source[prop])) {
-        obj[prop] = source[prop];
-      }
-      else if (_.isString(source[prop]) && parentRE.test(source[prop])) {
-        if (_.isString(obj[prop])) {
-          obj[prop] = source[prop].replace(parentRE, obj[prop]);
-        }
-      }
-      else if (_.isArray(obj[prop]) || _.isArray(source[prop])){
-        if (!_.isArray(obj[prop]) || !_.isArray(source[prop])){
-          throw new Error('Trying to combine an array with a non-array (' + prop + ')');
-        } else {
-          obj[prop] = _.reject(_.deepExtend(_.clone(obj[prop]), source[prop]), function (item) { return _.isNull(item);});
-        }
-      }
-      else if (_.isObject(obj[prop]) || _.isObject(source[prop])){
-        if (!_.isObject(obj[prop]) || !_.isObject(source[prop])){
-          throw new Error('Trying to combine an object with a non-object (' + prop + ')');
-        } else {
-          obj[prop] = _.deepExtend(_.clone(obj[prop]), source[prop]);
-        }
+let deepObjectExtend = function(target, source) {
+  for (let prop in source) {
+    if (source.hasOwnProperty(prop)) {
+      if (target[prop] && typeof source[prop] === 'object') {
+        deepObjectExtend(target[prop], source[prop]);
       } else {
-        obj[prop] = source[prop];
+        target[prop] = source[prop];
       }
     }
-  });
-  return obj;
+  }
+  return target;
 };
 
-_.mixin({ 'deepExtend': deepExtend });
-
-/**
- * Dependency: underscore.js ( http://documentcloud.github.com/underscore/ )
- *
- * Mix it in with underscore.js:
- * _.mixin({deepExtend: deepExtend});
- *
- * Call it like this:
- * var myObj = _.deepExtend(grandparent, child, grandchild, greatgrandchild)
- *
- * Notes:
- * Keep it DRY.
- * This function is especially useful if you're working with JSON config documents. It allows you to create a default
- * config document with the most common settings, then override those settings for specific cases. It accepts any
- * number of objects as arguments, giving you fine-grained control over your config document hierarchy.
- *
- * Special Features and Considerations:
- * - parentRE allows you to concatenate strings. example:
- *   var obj = _.deepExtend({url: "www.example.com"}, {url: "http://#{_}/path/to/file.html"});
- *   console.log(obj.url);
- *   output: "http://www.example.com/path/to/file.html"
- *
- * - parentRE also acts as a placeholder, which can be useful when you need to change one value in an array, while
- *   leaving the others untouched. example:
- *   var arr = _.deepExtend([100,    {id: 1234}, true,  "foo",  [250, 500]],
- *                          ["#{_}", "#{_}",     false, "#{_}", "#{_}"]);
- *   console.log(arr);
- *   output: [100, {id: 1234}, false, "foo", [250, 500]]
- *
- * - The previous example can also be written like this:
- *   var arr = _.deepExtend([100,    {id:1234},   true,  "foo",  [250, 500]],
- *                          ["#{_}", {},          false, "#{_}", []]);
- *   console.log(arr);
- *   output: [100, {id: 1234}, false, "foo", [250, 500]]
- *
- * - And also like this:
- *   var arr = _.deepExtend([100,    {id:1234},   true,  "foo",  [250, 500]],
- *                          ["#{_}", {},          false]);
- *   console.log(arr);
- *   output: [100, {id: 1234}, false, "foo", [250, 500]]
- *
- * - Array order is important. example:
- *   var arr = _.deepExtend([1, 2, 3, 4], [1, 4, 3, 2]);
- *   console.log(arr);
- *   output: [1, 4, 3, 2]
- *
- * - You can remove an array element set in a parent object by setting the same index value to null in a child object.
- *   example:
- *   var obj = _.deepExtend({arr: [1, 2, 3, 4]}, {arr: ["#{_}", null]});
- *   console.log(obj.arr);
- *   output: [1, 3, 4]
- *
- **/
+_.mixin({ 'deepExtend': deepObjectExtend });

--- a/tests/unit/module.unit.coffee
+++ b/tests/unit/module.unit.coffee
@@ -57,13 +57,8 @@ describe 'Space.Module - #initialize', ->
     @module = new Space.Module()
     # faked required modules to spy on
     @SubModule1 = Space.Module.define 'SubModule1'
-    @subModule1 = new @SubModule1()
     @SubModule2 = Space.Module.define 'SubModule2'
-    @subModule2 = new @SubModule2()
-    @app = modules: {
-      'SubModule1': @subModule1
-      'SubModule2': @subModule2
-    }
+    @app = modules: {}
 
   it 'asks the injector to inject dependencies into the module', ->
     @module.initialize @app, @injector
@@ -86,20 +81,17 @@ describe 'Space.Module - #initialize', ->
     @module.initialize @app, @injector
     expect(@module.onInitialize).to.have.been.calledOnce
 
-  it 'looks up required modules and adds them to the modules object', ->
-    # make our SUT module require our fake modules
+  it 'creates required modules and adds them to the app', ->
     @module.requiredModules = [@SubModule1.name, @SubModule2.name]
     @module.initialize @app, @injector
-    expect(@app.modules[@SubModule1.name]).to.equal @subModule1
-    expect(@app.modules[@SubModule2.name]).to.equal @subModule2
+    expect(@app.modules[@SubModule1.name]).to.be.instanceof(@SubModule1)
+    expect(@app.modules[@SubModule2.name]).to.be.instanceof(@SubModule2)
 
   it 'initializes required modules', ->
-    sinon.spy @subModule1, 'initialize'
-    sinon.spy @subModule2, 'initialize'
-    @module.requiredModules = [@SubModule1.name, @SubModule2.name]
+    sinon.stub @SubModule1.prototype, 'initialize'
+    @module.requiredModules = [@SubModule1.name]
     @module.initialize @app, @injector
-    expect(@subModule1.initialize).to.have.been.called
-    expect(@subModule2.initialize).to.have.been.called
+    expect(@SubModule1.prototype.initialize).to.have.been.calledOnce
 
   it 'can only be initialized once', ->
     @module.onInitialize = sinon.spy()


### PR DESCRIPTION
This PR fixes a severe bug in the app / module configuration logic. The code is backward-compatible and much simpler now because i reduced "the config" to a single `this.app.configuration` object in which all modules merge in their own configs in the right order. In the end this application config object is mapped and also assigned as `this.configuration` on all modules.

This also fixes a smaller issue with `Module::reset` – this could get called multiple times if a module is required by multiple other modules. I introduced a time-based (Meteor.defer) guard, even though this is not the most elegant solution, it does the job.