### PR TITLE
make structs serializable from and to plain data objects

### DIFF
--- a/source/struct.coffee
+++ b/source/struct.coffee
@@ -14,6 +14,24 @@ class Space.Struct extends Space.Object
     copy[key] = @[key] for key of @fields() when @[key] != undefined
     return copy
 
+  toData: ->
+    data = {}
+    for key, Type of @fields() when @[key] != undefined
+      if Type.isSubclassOf?(Space.Struct)
+        data[key] = @[key].toData()
+      else
+        data[key] = @[key]
+    return data
+
+  @fromData: (raw) ->
+    data = {}
+    for key, Type of this::fields() when raw[key] != undefined
+      if Type.isSubclassOf?(Space.Struct)
+        data[key] = Type.fromData raw[key]
+      else
+        data[key] = raw[key]
+    return new this(data)
+
   # Use the fields configuration to check given data during runtime
   _checkFields: (data) -> check data, @fields()
 

--- a/source/struct.coffee
+++ b/source/struct.coffee
@@ -15,10 +15,13 @@ class Space.Struct extends Space.Object
     return copy
 
   toData: ->
-    data = {}
+    data = { $type: @classPath() }
     for key, Type of @fields() when @[key] != undefined
       if Type.isSubclassOf?(Space.Struct)
         data[key] = @[key].toData()
+      else if _.isArray(Type)
+        for value in @[key]
+          data[key] = value.toData() if value instanceof Space.Struct
       else
         data[key] = @[key]
     return data

--- a/source/struct.coffee
+++ b/source/struct.coffee
@@ -1,4 +1,6 @@
 
+structTypes = {}
+
 class Space.Struct extends Space.Object
 
   @fields: {}
@@ -15,25 +17,42 @@ class Space.Struct extends Space.Object
     return copy
 
   toData: ->
-    data = { $type: @classPath() }
-    for key, Type of @fields() when @[key] != undefined
-      if Type.isSubclassOf?(Space.Struct)
-        data[key] = @[key].toData()
-      else if _.isArray(Type)
-        for value in @[key]
-          data[key] = value.toData() if value instanceof Space.Struct
+    if !@constructor.classPath?
+      throw new Error "You have to specify <#{@constructor.name}.classPath>
+                       to make it reconstructable from data"
+
+    data = { _type: @constructor.classPath }
+    for key of @fields() when @[key] != undefined
+      value = @[key]
+      if value instanceof Space.Struct
+        data[key] = value.toData()
+      else if _.isArray(value)
+        data[key] = value.map (v) -> if (v instanceof Space.Struct) then v.toData() else v
       else
-        data[key] = @[key]
+        data[key] = value
     return data
 
   @fromData: (raw) ->
     data = {}
     for key, Type of this::fields() when raw[key] != undefined
-      if Type.isSubclassOf?(Space.Struct)
-        data[key] = Type.fromData raw[key]
+      value = raw[key]
+      if value._type?
+        data[key] = structTypes[value._type].fromData raw[key]
+      else if _.isArray(value)
+        data[key] = value.map (v) ->
+          if v._type?
+            return structTypes[v._type].fromData v
+          else
+            return v
       else
-        data[key] = raw[key]
+        data[key] = value
     return new this(data)
+
+  @type: (path, Type=this) ->
+    Type.classPath = path
+    structTypes[path] = Type
+
+  @resolve: (path) -> structTypes[path]
 
   # Use the fields configuration to check given data during runtime
   _checkFields: (data) -> check data, @fields()

--- a/tests/unit/struct.unit.coffee
+++ b/tests/unit/struct.unit.coffee
@@ -1,26 +1,32 @@
 
 describe 'Space.Struct', ->
 
-  class TestStruct extends Space.Struct
+  struct = Space.namespace('struct')
+
+  class struct.TestStruct extends Space.Struct
+    @type 'struct.TestStruct'
     fields: -> name: String, age: Match.Integer
 
-  class ExtendedTestStruct extends TestStruct
+  class struct.ExtendedTestStruct extends struct.TestStruct
+    @type 'struct.ExtendedTestStruct'
     fields: ->
       fields = super()
       fields.extra = Match.Integer
       return fields
 
-  class StructWithNestedStructs extends Space.Struct
+  class struct.StructWithNestedStructs extends Space.Struct
+    @type 'struct.StructWithNestedStructs'
     fields: -> {
-      extended: ExtendedTestStruct
-      subs: [TestStruct]
+      extended: struct.ExtendedTestStruct
+      subs: [struct.TestStruct]
     }
 
   exampleNestedStructData = {
-    extended: { $type: 'ExtendedTestStruct', name: 'Test', age: 10, extra: 1 }
+    _type: 'struct.StructWithNestedStructs'
+    extended: { _type: 'struct.ExtendedTestStruct', name: 'Test', age: 10, extra: 1 }
     subs: [
-      { $type: 'TestStruct', name: 'Bla', age: 2 }
-      { $type: 'TestStruct', name: 'Blub', age: 5 }
+      { _type: 'struct.TestStruct', name: 'Bla', age: 2 }
+      { _type: 'struct.TestStruct', name: 'Blub', age: 5 }
     ]
   }
 
@@ -28,48 +34,48 @@ describe 'Space.Struct', ->
 
     it 'assigns the properties to the instance', ->
       properties = name: 'Dominik', age: 26
-      instance = new TestStruct properties
+      instance = new struct.TestStruct properties
       expect(instance).toMatch properties
 
     it 'provides a method to cast to plain object', ->
-      instance = new TestStruct name: 'Dominik', age: 26
+      instance = new struct.TestStruct name: 'Dominik', age: 26
       copy = instance.toPlainObject()
       expect(copy.name).to.equal 'Dominik'
       expect(copy.age).to.equal 26
       expect(copy).to.be.an.object
-      expect(copy).not.to.be.instanceof TestStruct
+      expect(copy).not.to.be.instanceof struct.TestStruct
 
     it 'throws a match error if a property is of wrong type', ->
-      expect(-> new TestStruct name: 5, age: 26).to.throw Match.Error
+      expect(-> new struct.TestStruct name: 5, age: 26).to.throw Match.Error
 
     it 'throws a match error if additional properties are given', ->
-      expect(-> new TestStruct name: 5, age: 26, extra: 0).to.throw Match.Error
+      expect(-> new struct.TestStruct name: 5, age: 26, extra: 0).to.throw Match.Error
 
     it 'throws a match error if a property is missing', ->
-      expect(-> new TestStruct name: 5).to.throw Match.Error
+      expect(-> new struct.TestStruct name: 5).to.throw Match.Error
 
     it 'allows to extend the fields of base classes', ->
-      expect(-> new ExtendedTestStruct name: 'test', age: 26, extra: 0)
+      expect(-> new struct.ExtendedTestStruct name: 'test', age: 26, extra: 0)
       .not.to.throw Match.Error
 
     # TODO: remove when breaking change is made for next major version:
     it 'stays backward compatible with static fields api', ->
-      class TestStruct extends Space.Struct
+      class StaticFieldsStruct extends Space.Struct
         @fields: { name: String, age: Match.Integer }
 
       properties = name: 'Dominik', age: 26
-      instance = new TestStruct properties
+      instance = new StaticFieldsStruct properties
       expect(instance).toMatch properties
-      expect(-> new TestStruct name: 5).to.throw Match.Error
+      expect(-> new StaticFieldsStruct name: 5).to.throw Match.Error
 
   describe "::toData", ->
 
     it "returns a hierarchy of plain data objects", ->
-      myStruct = new StructWithNestedStructs {
-        extended: new ExtendedTestStruct(name: 'Test', age: 10, extra: 1)
+      myStruct = new struct.StructWithNestedStructs {
+        extended: new struct.ExtendedTestStruct(name: 'Test', age: 10, extra: 1)
         subs: [
-          new TestStruct(name: 'Bla', age: 2)
-          new TestStruct(name: 'Blub', age: 5)
+          new struct.TestStruct(name: 'Bla', age: 2)
+          new struct.TestStruct(name: 'Blub', age: 5)
         ]
       }
       expect(myStruct.toData()).to.deep.equal exampleNestedStructData
@@ -78,9 +84,9 @@ describe 'Space.Struct', ->
 
     it "constructs the struct hierarchy from plain data object hierarchy", ->
 
-      myStruct = StructWithNestedStructs.fromData exampleNestedStructData
-      expect(myStruct).to.be.instanceOf(StructWithNestedStructs)
-      expect(myStruct.extended).to.be.instanceOf(ExtendedTestStruct)
+      myStruct = struct.StructWithNestedStructs.fromData exampleNestedStructData
+      expect(myStruct).to.be.instanceOf(struct.StructWithNestedStructs)
+      expect(myStruct.extended).to.be.instanceOf(struct.ExtendedTestStruct)
       expect(myStruct.subs[0].toData()).to.deep.equal exampleNestedStructData.subs[0]
       expect(myStruct.subs[1].toData()).to.deep.equal exampleNestedStructData.subs[1]
 

--- a/tests/unit/struct.unit.coffee
+++ b/tests/unit/struct.unit.coffee
@@ -1,19 +1,19 @@
 
 describe 'Space.Struct', ->
 
+  class TestStruct extends Space.Struct
+    fields: -> name: String, age: Match.Integer
+
+  class StructWithNestedStructFields extends Space.Struct
+    fields: -> sub: TestStruct
+
+  class ExtendedTestStruct extends TestStruct
+    fields: ->
+      fields = super()
+      fields.extra = Match.Integer
+      return fields
+
   describe 'defining fields', ->
-
-    class TestStruct extends Space.Struct
-      fields: -> name: String, age: Match.Integer
-
-    class StructWithNestedStructFields extends Space.Struct
-      fields: -> sub: TestStruct
-
-    class ExtendedTestStruct extends TestStruct
-      fields: ->
-        fields = super()
-        fields.extra = Match.Integer
-        return fields
 
     it 'assigns the properties to the instance', ->
       properties = name: 'Dominik', age: 26
@@ -50,3 +50,24 @@ describe 'Space.Struct', ->
       instance = new TestStruct properties
       expect(instance).toMatch properties
       expect(-> new TestStruct name: 5).to.throw Match.Error
+
+  describe "::toData", ->
+
+    it "returns a hierarchy of plain data objects", ->
+      myStruct = new StructWithNestedStructFields {
+        sub: new TestStruct(name: 'Test', age: 10)
+      }
+      expect(myStruct.toData()).to.deep.equal sub: { name: 'Test', age: 10 }
+
+  describe ".fromData", ->
+
+    it "constructs the struct hierarchy from plain data object hierarchy", ->
+
+      myStruct = StructWithNestedStructFields.fromData {
+        sub: { name: 'Test', age: 10 }
+      }
+      expect(myStruct).to.be.instanceOf(StructWithNestedStructFields)
+      expect(myStruct.sub).to.be.instanceOf(TestStruct)
+      expect(myStruct.sub.toData()).to.deep.equal name: 'Test', age: 10
+
+


### PR DESCRIPTION
Makes it possible to transform complete struct hierarchies to plain data objects and vice versa.
This will be used in the upcoming commit store refactoring, so that all our event and command data is saved as data that can be queried with mongoDB. Also for projections this will be useful, as we can now simply parse the pure data into structs / VOs :wink:  