### PR TITLE
remove serializing capabilities from structs again

### DIFF
--- a/source/struct.coffee
+++ b/source/struct.coffee
@@ -1,6 +1,4 @@
 
-structTypes = {}
-
 class Space.Struct extends Space.Object
 
   @fields: {}
@@ -15,44 +13,6 @@ class Space.Struct extends Space.Object
     copy = {}
     copy[key] = @[key] for key of @fields() when @[key] != undefined
     return copy
-
-  toData: ->
-    if !@constructor.classPath?
-      throw new Error "You have to specify <#{@constructor.name}.classPath>
-                       to make it reconstructable from data"
-
-    data = { _type: @constructor.classPath }
-    for key of @fields() when @[key] != undefined
-      value = @[key]
-      if value instanceof Space.Struct
-        data[key] = value.toData()
-      else if _.isArray(value)
-        data[key] = value.map (v) -> if (v instanceof Space.Struct) then v.toData() else v
-      else
-        data[key] = value
-    return data
-
-  @fromData: (raw) ->
-    data = {}
-    for key, Type of this::fields() when raw[key] != undefined
-      value = raw[key]
-      if value._type?
-        data[key] = structTypes[value._type].fromData raw[key]
-      else if _.isArray(value)
-        data[key] = value.map (v) ->
-          if v._type?
-            return structTypes[v._type].fromData v
-          else
-            return v
-      else
-        data[key] = value
-    return new this(data)
-
-  @type: (path, Type=this) ->
-    Type.classPath = path
-    structTypes[path] = Type
-
-  @resolve: (path) -> structTypes[path]
 
   # Use the fields configuration to check given data during runtime
   _checkFields: (data) -> check data, @fields()

--- a/tests/unit/struct.unit.coffee
+++ b/tests/unit/struct.unit.coffee
@@ -1,61 +1,43 @@
 
 describe 'Space.Struct', ->
 
-  struct = Space.namespace('struct')
-
-  class struct.TestStruct extends Space.Struct
-    @type 'struct.TestStruct'
+  class MyTestStruct extends Space.Struct
+    @type 'MyTestStruct'
     fields: -> name: String, age: Match.Integer
 
-  class struct.ExtendedTestStruct extends struct.TestStruct
-    @type 'struct.ExtendedTestStruct'
+  class MyExtendedTestStruct extends MyTestStruct
+    @type 'MyExtendedTestStruct'
     fields: ->
       fields = super()
       fields.extra = Match.Integer
       return fields
 
-  class struct.StructWithNestedStructs extends Space.Struct
-    @type 'struct.StructWithNestedStructs'
-    fields: -> {
-      extended: struct.ExtendedTestStruct
-      subs: [struct.TestStruct]
-    }
-
-  exampleNestedStructData = {
-    _type: 'struct.StructWithNestedStructs'
-    extended: { _type: 'struct.ExtendedTestStruct', name: 'Test', age: 10, extra: 1 }
-    subs: [
-      { _type: 'struct.TestStruct', name: 'Bla', age: 2 }
-      { _type: 'struct.TestStruct', name: 'Blub', age: 5 }
-    ]
-  }
-
   describe 'defining fields', ->
 
     it 'assigns the properties to the instance', ->
       properties = name: 'Dominik', age: 26
-      instance = new struct.TestStruct properties
+      instance = new MyTestStruct properties
       expect(instance).toMatch properties
 
     it 'provides a method to cast to plain object', ->
-      instance = new struct.TestStruct name: 'Dominik', age: 26
+      instance = new MyTestStruct name: 'Dominik', age: 26
       copy = instance.toPlainObject()
       expect(copy.name).to.equal 'Dominik'
       expect(copy.age).to.equal 26
       expect(copy).to.be.an.object
-      expect(copy).not.to.be.instanceof struct.TestStruct
+      expect(copy).not.to.be.instanceof MyTestStruct
 
     it 'throws a match error if a property is of wrong type', ->
-      expect(-> new struct.TestStruct name: 5, age: 26).to.throw Match.Error
+      expect(-> new MyTestStruct name: 5, age: 26).to.throw Match.Error
 
     it 'throws a match error if additional properties are given', ->
-      expect(-> new struct.TestStruct name: 5, age: 26, extra: 0).to.throw Match.Error
+      expect(-> new MyTestStruct name: 5, age: 26, extra: 0).to.throw Match.Error
 
     it 'throws a match error if a property is missing', ->
-      expect(-> new struct.TestStruct name: 5).to.throw Match.Error
+      expect(-> new MyTestStruct name: 5).to.throw Match.Error
 
     it 'allows to extend the fields of base classes', ->
-      expect(-> new struct.ExtendedTestStruct name: 'test', age: 26, extra: 0)
+      expect(-> new MyExtendedTestStruct name: 'test', age: 26, extra: 0)
       .not.to.throw Match.Error
 
     # TODO: remove when breaking change is made for next major version:
@@ -67,27 +49,5 @@ describe 'Space.Struct', ->
       instance = new StaticFieldsStruct properties
       expect(instance).toMatch properties
       expect(-> new StaticFieldsStruct name: 5).to.throw Match.Error
-
-  describe "::toData", ->
-
-    it "returns a hierarchy of plain data objects", ->
-      myStruct = new struct.StructWithNestedStructs {
-        extended: new struct.ExtendedTestStruct(name: 'Test', age: 10, extra: 1)
-        subs: [
-          new struct.TestStruct(name: 'Bla', age: 2)
-          new struct.TestStruct(name: 'Blub', age: 5)
-        ]
-      }
-      expect(myStruct.toData()).to.deep.equal exampleNestedStructData
-
-  describe ".fromData", ->
-
-    it "constructs the struct hierarchy from plain data object hierarchy", ->
-
-      myStruct = struct.StructWithNestedStructs.fromData exampleNestedStructData
-      expect(myStruct).to.be.instanceOf(struct.StructWithNestedStructs)
-      expect(myStruct.extended).to.be.instanceOf(struct.ExtendedTestStruct)
-      expect(myStruct.subs[0].toData()).to.deep.equal exampleNestedStructData.subs[0]
-      expect(myStruct.subs[1].toData()).to.deep.equal exampleNestedStructData.subs[1]
 
 


### PR DESCRIPTION
Removes the serialization capabilities from `Space.Struct` in favor of adding them to `Space.messaging.SerializableMixin`:
https://github.com/meteor-space/messaging/pull/18