### PR TITLE
introduce better namespacing and class lookup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .build*
 .DS_Store
+.idea

--- a/package.js
+++ b/package.js
@@ -1,8 +1,9 @@
 Package.describe({
   summary: 'Modular Application Architecture for Meteor.',
   name: 'space:base',
-  version: '3.2.1',
-  git: 'https://github.com/meteor-space/base.git'
+  version: '0.7.0',
+  git: 'https://github.com/meteor-space/base.git',
+  documentation: 'README.md'
 });
 
 Npm.depends({

--- a/package.js
+++ b/package.js
@@ -38,12 +38,12 @@ Package.onUse(function(api) {
   api.addFiles([
     'source/lib/underscore_deep_extend_mixin.js',
     'source/namespace.coffee',
+    'source/helpers.coffee',
     'source/configuration.js',
     'source/object.coffee',
     'source/logger.js',
     'source/struct.coffee',
     'source/error.js',
-    'source/helpers.coffee',
     'source/injector.coffee',
     'source/injector_annotations.coffee',
     'source/module.coffee',

--- a/source/error.js
+++ b/source/error.js
@@ -47,6 +47,7 @@ _.extend(Space.Error, {
   extend: Space.Object.extend,
   mixin: Space.Object.mixin,
   create: Space.Object.create,
+  type: Space.Object.type,
   _applyMixin: Space.Object._applyMixin,
   _mergeIntoPrototype: Space.Object._mergeIntoPrototype,
   __keepToStringMethod__: true // Do not override #toString method

--- a/source/helpers.coffee
+++ b/source/helpers.coffee
@@ -1,27 +1,25 @@
 
 global = this
 
-Space.Error.extend(Space, 'CouldNotResolvePathError', {
-  Constructor: (path) -> Space.Error.call(this, "'#{path}'")
-})
-
 # Resolves a (possibly nested) path to a global object
 # Returns the object or null (if not found)
 Space.resolvePath = (path) ->
-  if !path? then throw new Space.CouldNotResolvePathError(path)
+  if !path? then throw new Error "Cannot resolve invalid path <#{path}>"
   if path == '' then return global
+
+  # If there is a direct reference just return it
+  if Space.registry[path]? then return Space.registry[path]
+  if Space.Module?.published[path]? then return Space.Module.published[path]
   parts = path.split '.'
   result = global # Start with global namespace
   for key in parts # Move down the object chain
     result = result?[key] ? null
     # Take published space modules into account
     # to solve the Meteor package scoping problem
-    if !result? then result = Space.namespaces[key]
-    if !result? then result = Space.Module.published[key]
-    if !result? then throw new Space.CouldNotResolvePathError(path)
+    if !result? then throw new Error "Could not resolve path '#{path}'"
   return result
 
-Space.namespace = (id) -> Space.namespaces[id] = {}
+Space.namespace = (id) -> Space.registry[id] = new Space.Namespace(id)
 
 Space.capitalizeString = (string) ->
   string.charAt(0).toUpperCase() + string.slice(1)

--- a/source/namespace.coffee
+++ b/source/namespace.coffee
@@ -1,4 +1,8 @@
+class Namespace
+  constructor: (@_path) ->
+  getPath: -> this._path
+
 # Define global namespace for the space framework
-@Space = {
-  namespaces: {}
-}
+@Space = new Namespace 'Space'
+@Space.Namespace = Namespace
+@Space.registry = {}

--- a/source/object.coffee
+++ b/source/object.coffee
@@ -83,7 +83,7 @@ class Space.Object
           className = classPath.substr(classPath.lastIndexOf('.') + 1)
         else
           # className
-          className = args[0]
+          className = classPath = args[0]
 
     # Two params must be: (namespace, className) OR (className, extension) ->
     if args.length is 2
@@ -101,7 +101,7 @@ class Space.Object
           className = classPath.substr(classPath.lastIndexOf('.') + 1)
         else
           # className
-          className = args[0]
+          className = classPath = args[0]
 
     # All three params: (namespace, className, extension) ->
     if args.length is 3

--- a/tests/unit/object.unit.coffee
+++ b/tests/unit/object.unit.coffee
@@ -50,6 +50,11 @@ describe 'Space.Object', ->
         MyClass = Space.Object.extend('my.namespace.MyClass')
         expect(my.namespace.MyClass).to.equal(MyClass)
 
+      it "works correctly without nested namespaces", ->
+        MyClass = Space.Object.extend('MyClass')
+        expect(Space.resolvePath 'MyClass').to.equal(MyClass)
+
+
     describe "working with static class properties", ->
 
       it 'allows you to define static class properties', ->

--- a/tests/unit/object.unit.coffee
+++ b/tests/unit/object.unit.coffee
@@ -29,6 +29,27 @@ describe 'Space.Object', ->
       expect(instance.get('first')).to.equal 1
       expect(instance.get('second')).to.equal 2
 
+    describe "providing fully qualified class path", ->
+
+      it "registers the class for internal lookup", ->
+        Space.namespace('My.custom')
+        FirstClass = Space.Object.extend('My.custom.FirstClass', {})
+        SecondClass = Space.Object.extend('My.custom.SecondClass', {})
+        expect(Space.resolvePath 'My.custom.FirstClass').to.equal(FirstClass)
+        expect(Space.resolvePath 'My.custom.SecondClass').to.equal(SecondClass)
+
+      it "assigns the class path", ->
+        className = 'My.custom.Class'
+        MyClass = Space.Object.extend(className)
+        expect(MyClass.toString()).to.equal(className)
+        expect(new MyClass().toString()).to.equal(className)
+
+      it "exposes the class on the global scope if possible", ->
+        my = {}
+        my.namespace = Space.namespace('my.namespace')
+        MyClass = Space.Object.extend('my.namespace.MyClass')
+        expect(my.namespace.MyClass).to.equal(MyClass)
+
     describe "working with static class properties", ->
 
       it 'allows you to define static class properties', ->


### PR DESCRIPTION
This PR introduces a backward compatible way to define classes with fully qualified class path like this:
```javascript
// Anonymous namespace -> not on global scope!
Space.namespace('My.custom')
FirstClass = Space.Object.extend('My.custom.FirstClass', {})
Space.resolvePath('My.custom.FirstClass') // == FirstClass
```
or like this:
```javascript
// Namespace assigned to global scope
My.custom = Space.namespace('My.custom')
FirstClass = Space.Object.extend(My.custom, 'FirstClass', {})
Space.resolvePath('My.custom.FirstClass') // == FirstClass
```
which does a few things for us:

- Registers a `Space.Namespace` with the path `My.custom`
- Creates a class `FirstClass` which is attached to the namespace
- `FirstClass.classPath` and `FirstClass.toString()` returns the full path `'My.custom.FirstClass'`
- This is now default for *all* classes, so we can remove `FirstClass.type('My.custom.FirstClass')` from our code (this is done by `Space.Object.extend` now)

if you use Coffeescript with the `class` syntax, you still have to call `@type 'My.custom.FirstClass'` though since we have no control over the extension process there.

```coffeescript
# Namespace assigned to global scope
My.custom = Space.namespace('My.custom')
class FirstClass extends Space.Object
  @type 'My.custom.FirstClass'
Space.resolvePath('My.custom.FirstClass') // == FirstClass
```