### PR TITLE
improve Space.Error class setup to avoid future bugs

### DIFF
--- a/source/object.coffee
+++ b/source/object.coffee
@@ -3,15 +3,20 @@ class Space.Object
 
   # Assign given properties to the instance
   constructor: (properties) ->
-    # Let mixins initialize themselves on construction
-    for callback in @_getCallbacks(@constructor, 'onConstruction')
-      callback.apply(this, arguments)
+    @_invokeConstructionCallbacks.apply(this, arguments)
     # Copy properties to instance by default
     @[key] = value for key, value of properties
 
   onDependenciesReady: ->
     # Let mixins initialize themselves when dependencies are ready
     callback.call(this) for callback in @_getCallbacks(@constructor, 'onDependenciesReady')
+
+  toString: -> @constructor.toString()
+
+  _invokeConstructionCallbacks: ->
+    # Let mixins initialize themselves on construction
+    for callback in @_getCallbacks(@constructor, 'onConstruction')
+      callback.apply(this, arguments)
 
   _getCallbacks: (Class, callbackName) ->
     callbacks = "__#{callbackName}Callbacks__"
@@ -20,8 +25,6 @@ class Space.Object
       return _.union(superMixins, Class[callbacks] ? [])
     else
       return Class[callbacks] ? []
-
-  toString: -> @constructor.toString()
 
   # Extends this class and return a child class with inherited prototype
   # and static properties.

--- a/tests/unit/error.tests.js
+++ b/tests/unit/error.tests.js
@@ -46,4 +46,20 @@ describe("Space.Error", function() {
     expect(error.stack).to.be.a.string;
   });
 
+  describe("applying mixins", function() {
+
+    it("supports mixin callbacks", function() {
+      let MyMixin = {
+        onConstruction: sinon.spy(),
+        onDependenciesReady: sinon.spy()
+      };
+      let MyMixinError = Space.Error.extend('MyMixinError', { mixin: MyMixin });
+      let param = 'test';
+      let error = new MyMixinError(param);
+      expect(MyMixin.onConstruction).to.have.been.calledOn(error);
+      expect(MyMixin.onConstruction).to.have.been.calledWithExactly(param);
+    });
+
+  });
+
 });


### PR DESCRIPTION
Until now we copied over all methods of Space.Object
individually, which could get out of sync quickly.
Now we directly copy everything but omit the methods
that should not be copied for errors.

@darko-mijic maybe you can also try this with the `todos` app :wink: