### PR TITLE
invoke Space.Object constructor in structs

### DIFF
--- a/source/struct.coffee
+++ b/source/struct.coffee
@@ -5,7 +5,7 @@ class Space.Struct extends Space.Object
 
   constructor: (data={}) ->
     @_checkFields(data)
-    @_assignData(data)
+    super
 
   fields: -> _.clone(@constructor.fields) ? {}
 
@@ -16,6 +16,3 @@ class Space.Struct extends Space.Object
 
   # Use the fields configuration to check given data during runtime
   _checkFields: (data) -> check data, @fields()
-
-  # Copy data to instance
-  _assignData: (data) -> @[key] = data[key] for key of data

--- a/tests/unit/struct.unit.coffee
+++ b/tests/unit/struct.unit.coffee
@@ -12,6 +12,17 @@ describe 'Space.Struct', ->
       fields.extra = Match.Integer
       return fields
 
+  it "is a Space.Object", ->
+    expect(Space.Struct).to.extend(Space.Object)
+
+  it "calls the super constructor", ->
+    constructorSpy = sinon.spy(Space.Object.prototype, 'constructor')
+    data = {}
+    struct = new Space.Struct(data)
+    expect(constructorSpy).to.have.been.calledWithExactly(data)
+    expect(constructorSpy).to.have.been.calledOn(struct)
+    constructorSpy.restore()
+
   describe 'defining fields', ->
 
     it 'assigns the properties to the instance', ->


### PR DESCRIPTION
`Space.Struct` did not call the super constructor at all … this would keep mixins that rely `onConstruction` from working correctly … and it is something that should always be done anyway.