### PR TITLE
Fix/space object super class method

### DIFF
--- a/source/object.coffee
+++ b/source/object.coffee
@@ -233,6 +233,7 @@ class Space.Object
   # Returns either the super class constructor (if no param given) or
   # the static property or method with [key]
   @superClass: (key) ->
+    return undefined if !@__super__?
     sup = @__super__.constructor
     if key? then sup[key] else sup
 

--- a/tests/unit/object.unit.coffee
+++ b/tests/unit/object.unit.coffee
@@ -99,6 +99,9 @@ describe 'Space.Object', ->
       it "can return the super class", ->
         expect(Sub.superClass()).to.equal(Base)
 
+      it "returns null if there is no super class", ->
+        expect(Space.Object.superClass()).to.equal(undefined)
+
       it "can return a static prop or method of the super class", ->
         expect(Sub.superClass('prop')).to.equal(Base.prop)
         expect(Sub.superClass('method')).to.equal(Base.method)

--- a/tests/unit/object.unit.coffee
+++ b/tests/unit/object.unit.coffee
@@ -99,7 +99,7 @@ describe 'Space.Object', ->
       it "can return the super class", ->
         expect(Sub.superClass()).to.equal(Base)
 
-      it "returns null if there is no super class", ->
+      it "returns undefined if there is no super class", ->
         expect(Space.Object.superClass()).to.equal(undefined)
 
       it "can return a static prop or method of the super class", ->


### PR DESCRIPTION
This fixes the problem with mixin into a class that does not directly extend `Space.Object`, like seen here: (https://github.com/meteor-space/messaging/pull/36/files#diff-64cdd53ed92afe8dd60a8aa1e0aeaf5aR6)