### PR TITLE
Revert "Fix/space object super class method"

### DIFF
--- a/source/object.coffee
+++ b/source/object.coffee
@@ -233,7 +233,6 @@ class Space.Object
   # Returns either the super class constructor (if no param given) or
   # the static property or method with [key]
   @superClass: (key) ->
-    return undefined if !@__super__?
     sup = @__super__.constructor
     if key? then sup[key] else sup
 

--- a/tests/unit/object.unit.coffee
+++ b/tests/unit/object.unit.coffee
@@ -99,9 +99,6 @@ describe 'Space.Object', ->
       it "can return the super class", ->
         expect(Sub.superClass()).to.equal(Base)
 
-      it "returns undefined if there is no super class", ->
-        expect(Space.Object.superClass()).to.equal(undefined)
-
       it "can return a static prop or method of the super class", ->
         expect(Sub.superClass('prop')).to.equal(Base.prop)
         expect(Sub.superClass('method')).to.equal(Base.method)


### PR DESCRIPTION
Pulled against master instead of develop, and has not been treated as a hotfix