### PR TITLE
make it actually possible to BDD test a custom app instance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 Changelog
 =========
+## 4.1.3
+- Fixes the BDD test helper on `Space.Module` and `Space.Application` to actually accept a second param that can be a existing app instance.
+
 ## 4.1.2
 - Fixes superClass method for classes that are not directly extending Space.Object
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 Changelog
 =========
-## 4.1.3
+## Next
 - Fixes the BDD test helper on `Space.Module` and `Space.Application` to actually accept a second param that can be a existing app instance.
 
 ## 4.1.2

--- a/source/testing/bdd-api.coffee
+++ b/source/testing/bdd-api.coffee
@@ -11,16 +11,15 @@ Space.Module.test = Space.Application.test = (systemUnderTest, app=null) ->
   # BDD API relies on dependency injection provided by Application
   if !app?
     if isApplication
-      app = this
+      app = new this()
     else
-      app = Space.Application.define('TestApp', {
+      app = new (Space.Application.define('TestApp', {
         configuration: { appId: 'testApp' },
         requiredModules: [this.publishedAs]
-      })
-    appInstance = new app()
+      }))
 
   for api in registeredBddApis
-    returnValue = api(appInstance, systemUnderTest)
+    returnValue = api(app, systemUnderTest)
     testApi = returnValue if returnValue?
 
   if not testApi? then throw new Error "No testing API found for #{systemUnderTest}"


### PR DESCRIPTION
This fixes the BDD `test` helper on `Space.Module` and `Space.Application` to actually accept a second param that can be a existing app instance. We need that in the projection-rebuilding-example because there we just export a singleton app instance instead of the class. Anyway … this fix is necessary either way :wink: 